### PR TITLE
feat: add options analytics and worker fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GME Radar is a lightweight single-page dashboard that visualises GameStop’s li
 - **Automatic demo mode** – When the worker is unavailable the UI falls back to bundled samples replayed at 2× speed, keeping the charts populated.
 - **Intraday analytics** – Rolling VWAP, 1‑minute change, high/low range, and standard-deviation spike flags.
 - **Responsive charts** – uPlot candlesticks and volume histograms with adaptive resizing and animation throttling.
+- **Options analytics** – Server-proxied Polygon snapshots with Yahoo Finance fallback, moneyness heatmaps, unusual activity flags, and an alert ticker.
 - **GitHub Pages ready** – No build-time secrets, deterministic pnpm workflow, and a Pages deployment that works out of the box.
 
 ## Getting started
@@ -63,8 +64,9 @@ pnpm preview
 1. **Primary path** – `src/data/workerClient.ts` targets the Worker REST and WebSocket endpoints. Quotes poll every 3 s with `nocache=1`, minute candles refresh every 20 s, and the WS client performs exponential backoff with jitter.
 2. **Aggregation** – `src/data/ohlc.ts` rolls all trades into 1‑minute OHLC bars (last 390 minutes) to power the charts and analytics.
 3. **Signals** – `src/signals.ts` computes VWAP, 1‑minute change, daily high/low, and a 60-minute sigma spike indicator.
-4. **UI** – `src/ui/charts.ts` renders uPlot candlesticks and volume columns while `src/ui/status.ts` manages the status footer and banner.
-5. **Fallback** – `src/sim/simulator.ts` replays `public/demo/*.json` at 2× speed whenever both REST and WS fail for more than 10 s.
+4. **Options** – `src/data/optionsClient.ts` hits the Worker `/poly/options/chain` endpoint (Polygon with a server-side key) and downgrades to `/yahoo/options` when the key is missing or rate limited. `src/options/signals.ts` aggregates contracts by expiry and moneyness, while `src/ui/optionsPanel.ts` and `src/ui/alerts.ts` render the heatmap, unusual contract list, and rolling alert ticker.
+5. **UI** – `src/ui/charts.ts` renders uPlot candlesticks and volume columns while `src/ui/status.ts` manages the status footer and banner.
+6. **Fallback** – `src/sim/simulator.ts` replays `public/demo/*.json` at 2× speed whenever both REST and WS fail for more than 10 s.
 
 ## Cloudflare Worker proxy
 
@@ -74,7 +76,14 @@ All network calls originate from the browser to:
 - `GET /finnhub/stock/candle?symbol=SYM&resolution=1&from=…&to=…`
 - `WS /ws` sending `{ "type": "subscribe", "symbol": "SYM" }`
 
-The Worker injects the Finnhub token and handles upstream rate limits. No Finnhub keys live in this repository or the static bundle.
+Options activity uses additional endpoints:
+
+- `GET /poly/options/chain?underlying=SYM` injects the `POLYGON_KEY` server-side and returns normalised snapshots. Missing keys respond with `501` so the client can downgrade cleanly.
+- `GET /yahoo/options?symbol=SYM` proxies Yahoo Finance’s delayed chain JSON with a short cache window.
+
+The Worker injects the Finnhub token, shapes responses with permissive CORS headers, and keeps provider secrets off the client.
+
+Rate limits are handled with exponential backoff in the browser; if Polygon returns `429` or 5xx the app reuses the previous snapshot and automatically falls back to Yahoo-delayed data instead of blanking the UI.
 
 ## Demo mode
 

--- a/agents.md
+++ b/agents.md
@@ -1,58 +1,62 @@
-# GME Radar agent guide
+Title: GME Radar agent guide (Phase 3)
 
-## Scope
+What you’re maintaining
 
-You are an AI agent maintaining a static site that consumes a Cloudflare Worker proxy for Finnhub. Never add trading.
+A static site that pulls live equities via a Cloudflare Worker proxy and builds options analytics without exposing secrets.
 
-## Golden rules
+Providers:
 
-- Never expose or embed API keys in client code.
-- All market calls go through the Worker:
-  - REST: `/finnhub/...`
-  - WS: `/ws` with Finnhub-style subscribe frames
-- Build must succeed without secrets. When in doubt, default to demo mode.
-- Never break Pages deploy by introducing required env at build time.
+Equities: /finnhub/* REST and /ws
+Options primary: /poly/options/chain (server-injected key)
+Options fallback: /yahoo/options (delayed)
 
-## Runtime configuration
+Golden rules
 
-- `VITE_WORKER_ORIGIN` optional; default is same origin. Use it only at runtime via `new URL(path, VITE_WORKER_ORIGIN || location.origin)`.
-- Symbol comes from `?symbol=`. Default GME.
+Never embed API keys in browser code.
+All HTTP calls go through the Worker; builds must succeed with zero secrets.
+If any upstream is down/429, back off and keep UI rendering; prefer stale>blank.
 
-## Data contract
+Runtime config
 
-- `/finnhub/quote` returns Finnhub quote JSON with keys `c,d,dp,h,l,o,pc,t`.
-- `/finnhub/stock/candle` returns arrays `c,h,l,o,s,t,v`.
-- WS messages mirror Finnhub: `{ type: "trade", data: [{ p, s, t, v }] }` and pings.
-- Aggregation produces minute OHLC with fields `{ t, o, h, l, c, v }` rolling 390 bars.
+VITE_WORKER_ORIGIN optional. Default to same origin.
+Symbol comes from ?symbol=; default GME.
 
-## Error handling
+Data contracts
 
-- For REST 429 or 5xx, exponential backoff with jitter. Do not throw.
-- For WS close or error, reconnect with backoff and resubscribe. Keep a single socket.
-- If both REST and WS unavailable for 10s, switch to demo mode and show “DEMO” badge.
+Quote: /finnhub/quote → {c,d,dp,h,l,o,pc,t}
+Candles: /finnhub/stock/candle → arrays {c,h,l,o,s,t,v}
+Options chain normalized row:
 
-## Testing checklist
+{ ts, exp, type, strike, bid?, ask?, last?, mid?, volume?, openInterest?, iv? }
 
-- Live path: price updates within 2–5s, no duplicate bars, no memory leak on hot reload.
-- Demo path: charts render with sample data when Worker is unreachable.
-- Accessibility: focusable status controls, sufficient contrast.
+Aggregations:
 
-## CI rules
+Expiry totals: calls/puts volume, OI
+Moneyness matrix: deep ITM/ITM/ATM/OTM/deep OTM vs spot
+Alerts emitted with payload and source contract IDs
 
-- Use pnpm 9.12.1 and Node 20 with cache.
-- Build output in `dist`. No secret-gated steps.
-- Lint and typecheck must pass.
+Error handling playbook
 
-## Don’ts
+REST 429/5xx: exponential backoff with jitter, cap 30s
+Polygon 501/no key: switch to Yahoo fallback
+If both options sources fail: switch to demo data and show “DELAYED/DEMO” badge
 
-- Don’t scrape vendor endpoints directly from the browser.
-- Don’t hardcode worker hostnames; use relative URLs or `VITE_WORKER_ORIGIN`.
-- Don’t block UI on network calls. Always render.
+CI rules
 
-## Playbook
+pnpm 9.12.1; Node 20; cache pnpm
+No env required at build; never gate build on provider availability
+Lint/typecheck must pass
 
-- If quotes appear stale, confirm `nocache=1` is appended for `/quote`.
-- If WS floods, debounce UI updates to 15 Hz and aggregate trades to bars.
-- If deploy fails with “pnpm not found”, verify action order exactly as in this doc.
+Common pitfalls
 
-_End of agents.md._
+Missing nocache=1 on /finnhub/quote yields stale quotes
+Multiple WS connections after hot-reload; ensure cleanup
+Large JSON inlined by bundler; keep demo data in public/
+
+Verification checklist
+
+Heatmap updates at most every 30–60s; alerts roll in without jank
+Refresh keeps last known symbol and baselines
+Worker returns CORS-enabled JSON for both providers
+
+End agents.md.

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
+        background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 60%), #020617;
       }
 
       a {
@@ -42,7 +43,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1rem;
+        gap: 1.5rem;
         background: rgba(15, 23, 42, 0.9);
         backdrop-filter: blur(6px);
         position: sticky;
@@ -50,7 +51,7 @@
         z-index: 2;
       }
 
-      header h1 {
+      .header-title {
         font-size: clamp(1.25rem, 2vw, 1.75rem);
         margin: 0;
         display: flex;
@@ -58,65 +59,48 @@
         gap: 0.25rem;
       }
 
-      header h1 span:last-child {
+      .header-title span:last-child {
         font-size: 0.95rem;
         font-weight: 400;
         color: #94a3b8;
       }
 
-      main {
-        flex: 1;
-        display: grid;
-        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-        grid-template-rows: minmax(0, 1fr) auto;
+      .header-controls {
+        display: flex;
+        align-items: flex-end;
         gap: 1rem;
-        padding: clamp(1rem, 2vw, 2.5rem);
       }
 
-      @media (max-width: 960px) {
-        main {
-          grid-template-columns: minmax(0, 1fr);
-          grid-template-rows: auto auto auto;
-        }
-        .panel {
-          grid-column: auto !important;
-          grid-row: auto !important;
-        }
-      }
-
-      .panel {
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        border-radius: 0.75rem;
-        padding: 1rem;
-        background: rgba(15, 23, 42, 0.7);
+      .symbol-form {
         display: flex;
         flex-direction: column;
-        min-height: 0;
-        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+        gap: 0.25rem;
       }
 
-      .panel h2 {
-        margin: 0 0 0.5rem;
-        font-size: 1rem;
-        font-weight: 600;
-        letter-spacing: 0.01em;
+      .symbol-form label {
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #93c5fd;
       }
 
-      .chart-container {
-        flex: 1;
-        min-height: 240px;
+      .symbol-form input {
+        width: 6rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.8);
+        color: inherit;
       }
 
-      footer {
-        padding: 0.75rem clamp(1rem, 2vw, 2.5rem);
-        border-top: 1px solid rgba(148, 163, 184, 0.15);
-        background: rgba(15, 23, 42, 0.85);
-        font-size: 0.85rem;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 1rem;
-        flex-wrap: wrap;
+      .symbol-form input:focus-visible {
+        outline: 2px solid #38bdf8;
+        outline-offset: 2px;
+      }
+
+      .symbol-form small {
+        font-size: 0.7rem;
+        color: #64748b;
       }
 
       .metrics {
@@ -135,6 +119,237 @@
         color: #94a3b8;
       }
 
+      .dashboard {
+        flex: 1;
+        display: grid;
+        gap: 1rem;
+        padding: clamp(1rem, 2vw, 2.5rem);
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1.35fr);
+        grid-template-rows: minmax(0, 1fr) minmax(0, 0.9fr) auto;
+        grid-template-areas:
+          'price options'
+          'volume options'
+          'signals options';
+      }
+
+      .panel-price { grid-area: price; }
+      .panel-volume { grid-area: volume; }
+      .panel-options { grid-area: options; }
+      .panel-signals { grid-area: signals; }
+
+      @media (max-width: 960px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .dashboard {
+          grid-template-columns: minmax(0, 1fr);
+          grid-template-rows: repeat(4, auto);
+          grid-template-areas:
+            'price'
+            'volume'
+            'signals'
+            'options';
+        }
+      }
+
+      .panel {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 0.75rem;
+        padding: 1rem;
+        background: rgba(15, 23, 42, 0.75);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-height: 0;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35);
+      }
+
+      .panel h2 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .panel-options {
+        gap: 1rem;
+      }
+
+      .panel-options h3 {
+        margin: 0;
+        font-size: 0.95rem;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: #a5b4fc;
+      }
+
+      .chart-wrapper {
+        position: relative;
+        flex: 1;
+        min-height: 240px;
+        display: flex;
+      }
+
+      .chart-wrapper canvas,
+      .chart-wrapper svg {
+        width: 100% !important;
+        height: 100% !important;
+      }
+
+      .heatmap-wrapper {
+        overflow-x: auto;
+      }
+
+      .heatmap-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+      }
+
+      .heatmap-table th,
+      .heatmap-table td {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 0.5rem;
+        text-align: left;
+      }
+
+      .heatmap-table th {
+        font-weight: 600;
+        color: #cbd5f5;
+        background: rgba(30, 41, 59, 0.65);
+      }
+
+      .heatmap-cell {
+        border-radius: 0.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-width: 110px;
+      }
+
+      .heatmap-cell strong {
+        font-size: 0.85rem;
+      }
+
+      .heatmap-cell small {
+        font-size: 0.7rem;
+        color: #e2e8f0;
+      }
+
+      .heatmap-table td.empty {
+        text-align: center;
+        color: #94a3b8;
+        padding: 1rem;
+      }
+
+      .totals-strip {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .totals-item {
+        background: rgba(30, 41, 59, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 0.6rem;
+        padding: 0.6rem 0.75rem;
+        display: grid;
+        gap: 0.25rem;
+        font-size: 0.8rem;
+      }
+
+      .unusual-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+      }
+
+      .unusual-table th,
+      .unusual-table td {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 0.4rem 0.5rem;
+        text-align: left;
+      }
+
+      .unusual-table tbody tr:hover {
+        background: rgba(56, 189, 248, 0.12);
+      }
+
+      .flags-legend {
+        margin: 0;
+        font-size: 0.7rem;
+        color: #94a3b8;
+      }
+
+      .signals-list {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.5rem 1.25rem;
+        font-size: 0.85rem;
+      }
+
+      .signals-list dt {
+        color: #94a3b8;
+      }
+
+      .alerts-block {
+        margin-top: auto;
+        padding: 0.75rem;
+        border-radius: 0.75rem;
+        background: rgba(30, 41, 59, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .alerts-block strong {
+        font-size: 0.8rem;
+        letter-spacing: 0.05em;
+        color: #a5b4fc;
+        text-transform: uppercase;
+      }
+
+      .alerts-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.35rem;
+        max-height: 120px;
+        overflow-y: auto;
+      }
+
+      .alert-item {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.35rem 0.75rem;
+        align-items: baseline;
+        font-size: 0.75rem;
+      }
+
+      .alert-item time {
+        color: #64748b;
+        font-size: 0.7rem;
+      }
+
+      .alert-detail {
+        grid-column: 2 / 3;
+        color: #cbd5f5;
+      }
+
+      footer {
+        padding: 0.75rem clamp(1rem, 2vw, 2.5rem);
+        border-top: 1px solid rgba(148, 163, 184, 0.15);
+        background: rgba(15, 23, 42, 0.85);
+        font-size: 0.85rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
       .badge {
         display: inline-flex;
         align-items: center;
@@ -147,24 +362,25 @@
         letter-spacing: 0.04em;
       }
 
-      .badge.live {
-        background: rgba(34, 197, 94, 0.15);
-        color: #4ade80;
+      .badge.live { background: rgba(34, 197, 94, 0.15); color: #4ade80; }
+      .badge.reconnecting { background: rgba(250, 204, 21, 0.15); color: #facc15; }
+      .badge.offline { background: rgba(248, 113, 113, 0.1); color: #fca5a5; }
+      .badge.demo { background: rgba(147, 197, 253, 0.15); color: #93c5fd; }
+
+      .badge.provider {
+        background: rgba(56, 189, 248, 0.18);
+        color: #bae6fd;
+        font-size: 0.7rem;
       }
 
-      .badge.reconnecting {
-        background: rgba(250, 204, 21, 0.15);
-        color: #facc15;
+      .badge.provider.delayed {
+        background: rgba(250, 204, 21, 0.18);
+        color: #fde68a;
       }
 
-      .badge.offline {
-        background: rgba(248, 113, 113, 0.1);
-        color: #fca5a5;
-      }
-
-      .badge.demo {
-        background: rgba(147, 197, 253, 0.15);
-        color: #93c5fd;
+      .badge.provider.error {
+        background: rgba(248, 113, 113, 0.18);
+        color: #fecaca;
       }
 
       .banner {
@@ -176,23 +392,11 @@
         font-size: 0.9rem;
       }
 
-      .chart-wrapper {
-        position: relative;
-        flex: 1;
-        display: flex;
-        min-height: 240px;
-      }
-
-      .chart-wrapper canvas,
-      .chart-wrapper svg {
-        width: 100% !important;
-        height: 100% !important;
-      }
-
       .status-line {
         display: flex;
         align-items: center;
-        gap: 0.75rem;
+        flex-wrap: wrap;
+        gap: 0.6rem 1rem;
       }
 
       .status-line button {
@@ -216,6 +420,17 @@
       }
 
       .status-line time {
+        color: #94a3b8;
+      }
+
+      .worker-label,
+      .options-label {
+        font-size: 0.75rem;
+        color: #cbd5f5;
+      }
+
+      .small {
+        font-size: 0.75rem;
         color: #94a3b8;
       }
     </style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,22 @@
+export interface FeatureFlags {
+  demoOptionsFallback: boolean;
+}
+
+let cachedOrigin: string | null = null;
+
+export function getWorkerOrigin(): string {
+  if (cachedOrigin != null) {
+    return cachedOrigin;
+  }
+  if (typeof window === 'undefined') {
+    cachedOrigin = '';
+    return cachedOrigin;
+  }
+  const raw = (import.meta.env.VITE_WORKER_ORIGIN as string | undefined)?.trim() ?? '';
+  cachedOrigin = raw.length > 0 ? raw : window.location.origin;
+  return cachedOrigin;
+}
+
+export const features: FeatureFlags = {
+  demoOptionsFallback: true,
+};

--- a/src/data/optionsClient.ts
+++ b/src/data/optionsClient.ts
@@ -1,0 +1,180 @@
+import { getWorkerOrigin } from '../config';
+
+export interface OptRow {
+  ts: number;
+  exp: string;
+  type: 'C' | 'P';
+  strike: number;
+  bid?: number;
+  ask?: number;
+  last?: number;
+  mid?: number;
+  volume?: number;
+  openInterest?: number;
+  iv?: number;
+}
+
+export interface OptionsMeta {
+  source: 'polygon' | 'yahoo' | 'demo' | 'unknown';
+  delayed?: boolean;
+  error?: string;
+  status?: number;
+  updatedAt?: number;
+  [key: string]: unknown;
+}
+
+export interface OptionsResponse {
+  rows: OptRow[];
+  meta: OptionsMeta;
+}
+
+interface RequestResult {
+  ok: boolean;
+  status: number;
+  payload?: OptionsResponse;
+  error?: string;
+}
+
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE = 500;
+
+export async function fetchChain(symbol: string): Promise<OptionsResponse> {
+  const polyResult = await requestChain(`/poly/options/chain?underlying=${encodeURIComponent(symbol)}`);
+  if (polyResult.ok && polyResult.payload) {
+    const meta: OptionsMeta = {
+      ...(polyResult.payload.meta ?? {}),
+      source: 'polygon',
+    };
+    return { rows: polyResult.payload.rows, meta };
+  }
+
+  if (polyResult.status !== 501 && polyResult.status !== 0 && polyResult.status < 500 && polyResult.status !== 429) {
+    // Non-retriable error, but still attempt fallback to keep demo behaviour consistent.
+  }
+
+  const yahooResult = await requestChain(`/yahoo/options?symbol=${encodeURIComponent(symbol)}`);
+  if (yahooResult.ok && yahooResult.payload) {
+    const meta: OptionsMeta = {
+      ...(yahooResult.payload.meta ?? {}),
+      source: 'yahoo',
+      delayed: true,
+    };
+    return { rows: yahooResult.payload.rows, meta };
+  }
+
+  const error = yahooResult.error ?? polyResult.error ?? 'Options data unavailable';
+  return {
+    rows: [],
+    meta: {
+      source: yahooResult.ok ? 'yahoo' : polyResult.ok ? 'polygon' : 'unknown',
+      delayed: yahooResult.ok ? true : undefined,
+      error,
+      status: yahooResult.status || polyResult.status,
+    },
+  };
+}
+
+export async function fetchDailyOI(): Promise<OptionsResponse> {
+  // Placeholder: worker endpoint can supply dedicated daily OI snapshots in the future.
+  return { rows: [], meta: { source: 'unknown' } };
+}
+
+async function requestChain(path: string): Promise<RequestResult> {
+  const base = getWorkerOrigin() || (typeof window !== 'undefined' ? window.location.origin : '');
+  const url = new URL(path, base);
+  let lastError: string | undefined;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url.toString(), {
+        headers: { Accept: 'application/json' },
+      });
+      if (response.ok) {
+        const payload = await parsePayload(response);
+        return { ok: true, status: response.status, payload };
+      }
+      if (response.status === 429 || response.status >= 500) {
+        const delay = withJitter(RETRY_BASE * 2 ** attempt);
+        await sleep(delay);
+        continue;
+      }
+      const message = `Request failed (${response.status})`;
+      return { ok: false, status: response.status, error: message };
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : 'Network error';
+      const delay = withJitter(RETRY_BASE * 2 ** attempt);
+      await sleep(delay);
+    }
+  }
+  return { ok: false, status: 0, error: lastError ?? 'Request failed' };
+}
+
+async function parsePayload(response: Response): Promise<OptionsResponse> {
+  try {
+    const json = (await response.json()) as Partial<OptionsResponse> & { rows?: OptRow[]; meta?: OptionsMeta };
+    const rows = Array.isArray(json.rows) ? json.rows.map(normalizeRow).filter(Boolean) as OptRow[] : [];
+    const meta: OptionsMeta = {
+      source: json.meta?.source as OptionsMeta['source'] ?? 'unknown',
+      ...json.meta,
+    };
+    return { rows, meta };
+  } catch {
+    return {
+      rows: [],
+      meta: { source: 'unknown', error: 'Invalid payload' },
+    };
+  }
+}
+
+function normalizeRow(input: OptRow | undefined): OptRow | undefined {
+  if (!input) {
+    return undefined;
+  }
+  const type = input.type === 'P' ? 'P' : 'C';
+  const ts = typeof input.ts === 'number' ? input.ts : Date.now();
+  const strike = Number.isFinite(input.strike) ? Number(input.strike) : NaN;
+  if (!Number.isFinite(strike)) {
+    return undefined;
+  }
+  const bid = sanitizeNumber(input.bid);
+  const ask = sanitizeNumber(input.ask);
+  const mid = sanitizeNumber(input.mid) ?? computeMid(bid, ask, sanitizeNumber(input.last));
+  return {
+    ts,
+    exp: input.exp,
+    type,
+    strike,
+    bid,
+    ask,
+    last: sanitizeNumber(input.last),
+    mid,
+    volume: sanitizeNumber(input.volume),
+    openInterest: sanitizeNumber(input.openInterest),
+    iv: sanitizeNumber(input.iv),
+  };
+}
+
+function sanitizeNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function computeMid(bid?: number, ask?: number, last?: number): number | undefined {
+  if (bid != null && ask != null) {
+    return (bid + ask) / 2;
+  }
+  if (last != null) {
+    return last;
+  }
+  return bid ?? ask ?? undefined;
+}
+
+function withJitter(base: number): number {
+  const jitter = Math.random() * base * 0.25;
+  return Math.min(30_000, base + jitter);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/data/workerClient.ts
+++ b/src/data/workerClient.ts
@@ -1,3 +1,4 @@
+import { getWorkerOrigin } from '../config';
 import type { ConnectionState, Trade } from '../types';
 
 export interface Quote {
@@ -37,19 +38,8 @@ export interface LiveConnection {
   close(): void;
 }
 
-function resolveOrigin(): string {
-  if (typeof window === 'undefined') {
-    return '';
-  }
-  const raw = (import.meta.env.VITE_WORKER_ORIGIN as string | undefined) ?? '';
-  if (raw.trim().length === 0) {
-    return window.location.origin;
-  }
-  return raw;
-}
-
 function createWsUrl(): string {
-  const origin = resolveOrigin();
+  const origin = getWorkerOrigin();
   const target = origin || window.location.origin;
   const url = new URL('/ws', target);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -57,7 +47,7 @@ function createWsUrl(): string {
 }
 
 export async function fetchQuote(symbol: string, signal?: AbortSignal): Promise<Quote> {
-  const url = new URL('/finnhub/quote', resolveOrigin() || window.location.origin);
+  const url = new URL('/finnhub/quote', getWorkerOrigin() || window.location.origin);
   url.searchParams.set('symbol', symbol);
   url.searchParams.set('nocache', '1');
   const response = await fetch(url.toString(), {
@@ -78,7 +68,7 @@ export async function fetchCandles(
   resolution: '1',
   signal?: AbortSignal,
 ): Promise<Candle[]> {
-  const url = new URL('/finnhub/stock/candle', resolveOrigin() || window.location.origin);
+  const url = new URL('/finnhub/stock/candle', getWorkerOrigin() || window.location.origin);
   url.searchParams.set('symbol', symbol);
   url.searchParams.set('resolution', resolution);
   url.searchParams.set('from', Math.floor(from / 1000).toString());

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,20 @@ import {
   fetchCandles as fetchWorkerCandles,
   fetchQuote as fetchWorkerQuote,
 } from './data/workerClient';
+import { fetchChain, type OptRow, type OptionsResponse } from './data/optionsClient';
+import { createBaselineStore, getExpiryKey, toOccSymbol } from './options/chain';
+import {
+  aggregateByExpiry,
+  aggregateByMoneyness,
+  detectSweepHeuristic,
+  flagIVSpike,
+  flagUnusualVolume,
+  type SweepSignal,
+} from './options/signals';
 import { summarizeSignals } from './signals';
 import { createPriceChart, createVolumeChart } from './ui/charts';
+import { createOptionsPanel, type UnusualContractRow } from './ui/optionsPanel';
+import { createAlertsTicker } from './ui/alerts';
 import { createStatus } from './ui/status';
 import type { Candle, LiveConnection, Quote } from './data/workerClient';
 import type { MinuteBar, Trade } from './types';
@@ -16,9 +28,18 @@ import {
   fetchCandles as fetchSimulatorCandles,
   fetchQuote as fetchSimulatorQuote,
 } from './sim/simulator';
+import { getWorkerOrigin } from './config';
+import { loadState, saveState } from './persist';
+
+interface OptionsSnapshotState {
+  rows: OptRow[];
+  meta: OptionsResponse['meta'];
+  spot: number | null;
+}
 
 const params = new URLSearchParams(window.location.search);
-const symbol = (params.get('symbol') ?? 'GME').toUpperCase();
+const persisted = loadState();
+let symbol = (params.get('symbol') ?? persisted?.symbol ?? 'GME').toUpperCase();
 const app = document.querySelector<HTMLDivElement>('#app');
 if (!app) {
   throw new Error('Missing app root');
@@ -31,6 +52,28 @@ const subtitleLine = document.createElement('span');
 titleLine.textContent = 'GME Radar';
 subtitleLine.textContent = `${symbol} realtime dashboard`;
 title.append(titleLine, subtitleLine);
+
+title.className = 'header-title';
+
+const controls = document.createElement('div');
+controls.className = 'header-controls';
+
+const symbolForm = document.createElement('form');
+symbolForm.className = 'symbol-form';
+const symbolLabel = document.createElement('label');
+symbolLabel.textContent = 'Symbol';
+symbolLabel.htmlFor = 'symbol-input';
+const symbolInput = document.createElement('input');
+symbolInput.id = 'symbol-input';
+symbolInput.type = 'text';
+symbolInput.value = symbol;
+symbolInput.maxLength = 6;
+symbolInput.autocomplete = 'off';
+const symbolHint = document.createElement('small');
+symbolHint.className = 'small';
+symbolHint.textContent = 'Press Enter to load';
+symbolForm.append(symbolLabel, symbolInput, symbolHint);
+controls.append(symbolForm);
 
 const metrics = document.createElement('div');
 metrics.className = 'metrics';
@@ -45,7 +88,8 @@ const rangeValue = document.createElement('small');
 rangeValue.textContent = 'Hi/Lo —';
 
 metrics.append(priceValue, changeValue, vwapValue, rangeValue);
-header.append(title, metrics);
+
+header.append(title, controls, metrics);
 app.append(header);
 
 const statusUi = createStatus();
@@ -53,66 +97,97 @@ statusUi.banner.hidden = true;
 app.append(statusUi.banner);
 
 const main = document.createElement('main');
+main.className = 'dashboard';
+
 const pricePanel = createPanel('Price action');
-pricePanel.style.gridColumn = '1 / 2';
-pricePanel.style.gridRow = '1 / 2';
+pricePanel.classList.add('panel-price');
 const priceChartContainer = document.createElement('div');
 priceChartContainer.className = 'chart-wrapper';
 pricePanel.append(priceChartContainer);
 
 const volumePanel = createPanel('Volume');
-volumePanel.style.gridColumn = '1 / 2';
-volumePanel.style.gridRow = '2 / 3';
+volumePanel.classList.add('panel-volume');
 const volumeChartContainer = document.createElement('div');
 volumeChartContainer.className = 'chart-wrapper';
 volumePanel.append(volumeChartContainer);
 
 const signalPanel = createPanel('Signals & flags');
-signalPanel.style.gridColumn = '2 / 3';
-signalPanel.style.gridRow = '1 / 3';
+signalPanel.classList.add('panel-signals');
 const signalsList = document.createElement('dl');
-signalsList.style.display = 'grid';
-signalsList.style.gridTemplateColumns = 'auto 1fr';
-signalsList.style.gap = '0.5rem 1.5rem';
+signalsList.className = 'signals-list';
 
 const vwapItem = createSignal(signalsList, 'VWAP');
 const highItem = createSignal(signalsList, 'High');
 const lowItem = createSignal(signalsList, 'Low');
 const changeItem = createSignal(signalsList, '1m change');
 const spikeItem = createSignal(signalsList, 'Spike');
-
 signalPanel.append(signalsList);
 
-main.append(pricePanel, volumePanel, signalPanel);
+const optionsPanel = createOptionsPanel();
+optionsPanel.element.classList.add('panel-options');
+
+const alertsTicker = createAlertsTicker();
+alertsTicker.element.classList.add('alerts-block');
+signalPanel.append(alertsTicker.element);
+
+main.append(pricePanel, volumePanel, optionsPanel.element, signalPanel);
 app.append(main);
 app.append(statusUi.element);
 
 const priceChart = createPriceChart(priceChartContainer);
 const volumeChart = createVolumeChart(volumeChartContainer);
 
-const aggregator = new MinuteOhlcAggregator(390);
-
+let aggregator = new MinuteOhlcAggregator(390);
 let mode: 'worker' | 'demo' = 'worker';
 let connection: LiveConnection | null = null;
 let quoteTimer: number | undefined;
 let candleTimer: number | undefined;
+let optionsTimer: number | undefined;
 let healthTimer: number | undefined;
 let retryCount = 0;
 let lastDataAt = Date.now();
 let pendingFrame = false;
+let lastSpot: number | null = persisted?.options?.chain?.spot ?? null;
+let baselineStore = createBaselineStore(persisted?.options?.baselines);
+let lastChain: OptionsSnapshotState | null = persisted?.options?.chain
+  ? {
+      rows: persisted.options.chain.rows,
+      meta: ((persisted.options.chain.meta ?? {}) as OptionsResponse['meta']) ?? { source: 'unknown' },
+      spot: persisted.options.chain.spot ?? null,
+    }
+  : null;
+const alertHistory = new Map<string, number>();
+let optionsInFlight = false;
 
 statusUi.setMode('live');
 statusUi.setConnection('connecting');
 statusUi.setBanner(null);
+statusUi.setWorkerOrigin(formatWorkerOrigin());
+statusUi.setOptionsStatus('—');
+statusUi.setOptionsUpdated(lastChain?.rows.at(0)?.ts ?? null);
 statusUi.retryButton.addEventListener('click', () => {
   retryCount = 0;
   statusUi.setRetries(retryCount);
   if (mode === 'worker') {
     void refreshQuote();
     void refreshCandles(true);
+    void refreshOptions(true);
   }
 });
 statusUi.setRetries(retryCount);
+
+if (lastChain) {
+  hydrateOptionsPanel(lastChain);
+}
+
+symbolForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const next = symbolInput.value.trim().toUpperCase();
+  if (!next || next === symbol) {
+    return;
+  }
+  changeSymbol(next);
+});
 
 void bootstrap();
 
@@ -135,6 +210,7 @@ async function loadWorker() {
     fetchWorkerQuote(symbol),
     fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1'),
   ]);
+  aggregator = new MinuteOhlcAggregator(390);
   const bars = convertCandles(candles);
   aggregator.seed(bars);
   applyQuote(quote);
@@ -147,6 +223,10 @@ async function loadWorker() {
   candleTimer = window.setInterval(() => {
     void refreshCandles();
   }, 20000);
+  optionsTimer = window.setInterval(() => {
+    void refreshOptions();
+  }, 45000);
+  await refreshOptions(true);
   startHealthCheck();
 }
 
@@ -159,10 +239,16 @@ async function enterDemo(reason: string) {
   connection?.close();
   connection = null;
   const [quote, candles] = await Promise.all([fetchSimulatorQuote(symbol), fetchSimulatorCandles(symbol)]);
+  aggregator = new MinuteOhlcAggregator(390);
   aggregator.seed(candles);
   applyQuote(quote);
   scheduleUpdate();
   connectStream(connectSimulator(symbol));
+  if (optionsTimer == null) {
+    optionsTimer = window.setInterval(() => {
+      void refreshOptions();
+    }, 60000);
+  }
 }
 
 function connectStream(newConnection: LiveConnection) {
@@ -227,6 +313,138 @@ async function refreshCandles(force = false) {
   }
 }
 
+async function refreshOptions(suppressAlerts = false) {
+  if (optionsInFlight) {
+    return;
+  }
+  optionsInFlight = true;
+  try {
+    const response = await fetchChain(symbol);
+    if (response.rows.length === 0) {
+      const provider = response.meta?.source ? response.meta.source.toUpperCase() : 'OFFLINE';
+      optionsPanel.setSource({
+        provider,
+        delayed: Boolean(response.meta?.delayed),
+        error: response.meta?.error,
+        updatedAt: lastChain?.rows.at(0)?.ts ?? null,
+      });
+      statusUi.setOptionsStatus(provider, Boolean(response.meta?.delayed));
+      optionsInFlight = false;
+      return;
+    }
+    const spot = determineSpot();
+    lastSpot = spot;
+    const snapshot: OptionsSnapshotState = {
+      rows: response.rows,
+      meta: response.meta,
+      spot,
+    };
+    renderOptionsSnapshot(snapshot, { suppressAlerts });
+    lastChain = snapshot;
+    statusUi.setOptionsStatus(response.meta.source?.toUpperCase?.() ?? '—', Boolean(response.meta.delayed));
+    const updatedAt = response.rows[0]?.ts ?? Date.now();
+    statusUi.setOptionsUpdated(updatedAt);
+    optionsPanel.setSource({
+      provider: response.meta.source?.toUpperCase?.() ?? '—',
+      delayed: Boolean(response.meta.delayed),
+      error: response.meta.error,
+      updatedAt,
+    });
+    saveState({
+      symbol,
+      options: {
+        chain: {
+          symbol,
+          rows: response.rows,
+          meta: response.meta,
+          spot,
+          updatedAt: Date.now(),
+        },
+        baselines: baselineStore.toJSON(),
+      },
+    });
+  } catch (error) {
+    console.warn('Options fetch failed', error);
+  } finally {
+    optionsInFlight = false;
+  }
+}
+
+function renderOptionsSnapshot(snapshot: OptionsSnapshotState, opts?: { suppressAlerts?: boolean }) {
+  const { rows, spot } = snapshot;
+  const suppressAlerts = Boolean(opts?.suppressAlerts);
+  const prevMap = new Map<string, OptRow>();
+  lastChain?.rows.forEach((row) => prevMap.set(toOccSymbol(symbol, row), row));
+  const sweepEvents = detectSweepHeuristic(rows);
+  const sweepIndex = new Set<string>();
+  sweepEvents.forEach((event) => {
+    const identifier = `${event.exp}|${event.type}`;
+    event.strikes.forEach((strike) => sweepIndex.add(`${identifier}|${strike}`));
+    if (!suppressAlerts) {
+      emitSweepAlert(event);
+    }
+  });
+
+  const unusual: UnusualContractRow[] = [];
+  rows.forEach((row) => {
+    const occ = toOccSymbol(symbol, row);
+    const baseline = baselineStore.getVolumeAverage(occ);
+    const ivStats = baselineStore.getIvStats(getExpiryKey(row));
+    const volFlag = flagUnusualVolume(row, baseline);
+    const ivFlag = flagIVSpike(row, ivStats);
+    const sweepFlag = sweepIndex.has(`${row.exp}|${row.type}|${row.strike}`);
+    const previous = prevMap.get(occ);
+    const deltaOi =
+      previous && previous.openInterest != null && row.openInterest != null
+        ? row.openInterest - previous.openInterest
+        : undefined;
+    const flags: string[] = [];
+    if (volFlag) {
+      flags.push('Vol >3×');
+      if (!suppressAlerts) {
+        emitAlert(`vol:${occ}`, 'UnusualVol', `${row.type} ${row.exp} ${row.strike.toFixed(2)}`, `Vol ${formatNumber(row.volume)}`);
+      }
+    }
+    if (ivFlag) {
+      flags.push('IV spike');
+      const ivLabel = row.iv != null ? `${(row.iv * 100).toFixed(1)}%` : '—';
+      if (!suppressAlerts) {
+        emitAlert(`iv:${occ}`, 'IVSpike', `${row.type} ${row.exp} ${row.strike.toFixed(2)}`, `IV ${ivLabel}`);
+      }
+    }
+    if (sweepFlag) {
+      flags.push('Sweep');
+    }
+    if (deltaOi != null && Math.abs(deltaOi) >= determineOiThreshold(previous?.openInterest)) {
+      flags.push('OI Δ');
+    }
+    baselineStore.recordVolume(occ, row.ts, row.volume ?? 0);
+    baselineStore.recordIv(getExpiryKey(row), row.ts, row.iv ?? 0);
+    if (flags.length > 0) {
+      unusual.push({ row, contractId: occ, flags, deltaOpenInterest: deltaOi });
+    }
+  });
+
+  const matrix = aggregateByMoneyness(rows, spot ?? determineSpot());
+  const totals = aggregateByExpiry(rows);
+  optionsPanel.renderHeatmap(matrix);
+  optionsPanel.renderTotals(totals);
+  optionsPanel.renderUnusual(unusual.sort((a, b) => (b.row.volume ?? 0) - (a.row.volume ?? 0)));
+}
+
+function hydrateOptionsPanel(snapshot: OptionsSnapshotState) {
+  const meta = snapshot.meta;
+  optionsPanel.setSource({
+    provider: meta.source?.toUpperCase?.() ?? '—',
+    delayed: Boolean(meta.delayed),
+    error: meta.error,
+    updatedAt: snapshot.rows[0]?.ts ?? null,
+  });
+  statusUi.setOptionsStatus(meta.source?.toUpperCase?.() ?? '—', Boolean(meta.delayed));
+  statusUi.setOptionsUpdated(snapshot.rows[0]?.ts ?? null);
+  renderOptionsSnapshot(snapshot, { suppressAlerts: true });
+}
+
 function scheduleUpdate() {
   if (pendingFrame) {
     return;
@@ -240,6 +458,7 @@ function scheduleUpdate() {
     const summary = summarizeSignals(bars);
     const latest = bars.at(-1);
     if (latest) {
+      lastSpot = latest.c;
       priceValue.textContent = formatCurrency(latest.c);
       const prev = bars.at(-2);
       const change = prev ? latest.c - prev.c : 0;
@@ -286,6 +505,10 @@ function stopTimers() {
     window.clearInterval(candleTimer);
     candleTimer = undefined;
   }
+  if (optionsTimer != null) {
+    window.clearInterval(optionsTimer);
+    optionsTimer = undefined;
+  }
   if (healthTimer != null) {
     window.clearInterval(healthTimer);
     healthTimer = undefined;
@@ -309,6 +532,7 @@ function ensureMilliseconds(value: number): number {
 
 function applyQuote(quote: Quote) {
   aggregator.touchPrice(quote.c, ensureMilliseconds(quote.t));
+  lastSpot = quote.c;
   lastDataAt = Date.now();
 }
 
@@ -346,4 +570,99 @@ function formatRange(high: number | null, low: number | null): string {
     return 'Hi/Lo —';
   }
   return `Hi/Lo ${formatCurrency(high)} / ${formatCurrency(low)}`;
+}
+
+function formatNumber(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  if (Math.abs(value) >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return value.toFixed(0);
+}
+
+function emitAlert(key: string, type: 'IVSpike' | 'UnusualVol', summary: string, detail?: string) {
+  const ts = Date.now();
+  const last = alertHistory.get(key);
+  if (last && ts - last < 120_000) {
+    return;
+  }
+  alertHistory.set(key, ts);
+  alertsTicker.push({ ts, type, summary, detail });
+}
+
+function emitSweepAlert(event: SweepSignal) {
+  const key = `sweep:${symbol}:${event.exp}:${event.type}:${event.strikes[0]}:${event.strikes.at(-1)}`;
+  const last = alertHistory.get(key);
+  if (last && event.ts - last < 120_000) {
+    return;
+  }
+  alertHistory.set(key, event.ts);
+  const detail = `Strikes ${event.strikes.join(' → ')} | Vol ${formatNumber(event.totalVolume)}`;
+  alertsTicker.push({
+    ts: event.ts,
+    type: 'Sweep',
+    summary: `${event.type} ${event.exp} sweep (${event.direction})`,
+    detail,
+  });
+}
+
+function determineSpot(): number {
+  if (lastSpot != null) {
+    return lastSpot;
+  }
+  const bars = aggregator.getBars();
+  const latest = bars.at(-1);
+  return latest?.c ?? 0;
+}
+
+function determineOiThreshold(previous: number | undefined | null): number {
+  if (previous == null) {
+    return 1;
+  }
+  return Math.max(1, Math.abs(previous) * 0.1);
+}
+
+function changeSymbol(next: string) {
+  stopTimers();
+  connection?.close();
+  connection = null;
+  symbol = next;
+  symbolInput.value = symbol;
+  subtitleLine.textContent = `${symbol} realtime dashboard`;
+  alertsTicker.reset();
+  lastChain = null;
+  lastSpot = null;
+  baselineStore = createBaselineStore();
+  aggregator = new MinuteOhlcAggregator(390);
+  priceChart.update([]);
+  volumeChart.update([]);
+  retryCount = 0;
+  statusUi.setRetries(0);
+  statusUi.setLastUpdated(null);
+  statusUi.setOptionsStatus('—');
+  statusUi.setOptionsUpdated(null);
+  optionsPanel.renderHeatmap([]);
+  optionsPanel.renderTotals([]);
+  optionsPanel.renderUnusual([]);
+  const url = new URL(window.location.href);
+  url.searchParams.set('symbol', symbol);
+  window.history.replaceState(null, '', url.toString());
+  alertHistory.clear();
+  saveState({ symbol });
+  void bootstrap();
+}
+
+function formatWorkerOrigin(): string {
+  const origin = getWorkerOrigin();
+  if (!origin) {
+    return window.location.origin;
+  }
+  try {
+    const url = new URL(origin);
+    return url.host;
+  } catch {
+    return origin;
+  }
 }

--- a/src/options/chain.ts
+++ b/src/options/chain.ts
@@ -1,0 +1,238 @@
+import type { OptRow } from '../data/optionsClient';
+
+export type MoneynessBucket = 'deepITM' | 'itm' | 'atm' | 'otm' | 'deepOTM';
+
+interface BaselineSample {
+  date: string;
+  value: number;
+}
+
+interface VolumeBaselineEntry {
+  samples: BaselineSample[];
+  average: number;
+  updatedAt: number;
+}
+
+interface IvBaselineEntry {
+  samples: BaselineSample[];
+  median: number;
+  mean: number;
+  stdDev: number;
+  updatedAt: number;
+}
+
+export interface BaselineSnapshot {
+  volume: Record<string, VolumeBaselineEntry>;
+  iv: Record<string, IvBaselineEntry>;
+}
+
+export interface IvStats {
+  median: number;
+  mean: number;
+  stdDev: number;
+}
+
+export interface BaselineStore {
+  recordVolume(occ: string, timestamp: number, volume: number): number | null;
+  recordIv(key: string, timestamp: number, iv: number): IvStats | null;
+  getVolumeAverage(occ: string): number | null;
+  getIvStats(key: string): IvStats | null;
+  toJSON(): BaselineSnapshot;
+}
+
+const MAX_SAMPLES = 30;
+
+export const MONEYNESS_ORDER: MoneynessBucket[] = ['deepITM', 'itm', 'atm', 'otm', 'deepOTM'];
+
+export function createBaselineStore(snapshot?: BaselineSnapshot): BaselineStore {
+  const volumeMap = new Map<string, VolumeBaselineEntry>();
+  const ivMap = new Map<string, IvBaselineEntry>();
+
+  if (snapshot) {
+    Object.entries(snapshot.volume ?? {}).forEach(([occ, entry]) => {
+      if (entry && Array.isArray(entry.samples)) {
+        volumeMap.set(occ, {
+          samples: entry.samples.slice(-MAX_SAMPLES),
+          average: entry.average ?? average(entry.samples.map((sample) => sample.value)),
+          updatedAt: entry.updatedAt ?? Date.now(),
+        });
+      }
+    });
+    Object.entries(snapshot.iv ?? {}).forEach(([key, entry]) => {
+      if (entry && Array.isArray(entry.samples)) {
+        const stats = computeStats(entry.samples.map((sample) => sample.value));
+        ivMap.set(key, {
+          samples: entry.samples.slice(-MAX_SAMPLES),
+          median: entry.median ?? stats.median,
+          mean: entry.mean ?? stats.mean,
+          stdDev: entry.stdDev ?? stats.stdDev,
+          updatedAt: entry.updatedAt ?? Date.now(),
+        });
+      }
+    });
+  }
+
+  function recordVolume(occ: string, timestamp: number, volume: number): number | null {
+    if (!Number.isFinite(volume) || volume <= 0) {
+      return getVolumeAverage(occ);
+    }
+    const entry = volumeMap.get(occ) ?? { samples: [], average: 0, updatedAt: 0 };
+    upsertSample(entry.samples, timestamp, volume);
+    entry.average = average(entry.samples.map((sample) => sample.value));
+    entry.updatedAt = Date.now();
+    volumeMap.set(occ, entry);
+    return entry.average || null;
+  }
+
+  function recordIv(key: string, timestamp: number, iv: number): IvStats | null {
+    if (!Number.isFinite(iv) || iv <= 0) {
+      return getIvStats(key);
+    }
+    const entry = ivMap.get(key) ?? { samples: [], median: 0, mean: 0, stdDev: 0, updatedAt: 0 };
+    upsertSample(entry.samples, timestamp, iv);
+    const stats = computeStats(entry.samples.map((sample) => sample.value));
+    entry.median = stats.median;
+    entry.mean = stats.mean;
+    entry.stdDev = stats.stdDev;
+    entry.updatedAt = Date.now();
+    ivMap.set(key, entry);
+    return stats;
+  }
+
+  function getVolumeAverage(occ: string): number | null {
+    return volumeMap.get(occ)?.average ?? null;
+  }
+
+  function getIvStats(key: string): IvStats | null {
+    const entry = ivMap.get(key);
+    if (!entry) {
+      return null;
+    }
+    return { median: entry.median, mean: entry.mean, stdDev: entry.stdDev };
+  }
+
+  function toJSON(): BaselineSnapshot {
+    const volume: Record<string, VolumeBaselineEntry> = {};
+    const iv: Record<string, IvBaselineEntry> = {};
+    volumeMap.forEach((entry, key) => {
+      volume[key] = {
+        samples: entry.samples.slice(-MAX_SAMPLES),
+        average: entry.average,
+        updatedAt: entry.updatedAt,
+      };
+    });
+    ivMap.forEach((entry, key) => {
+      iv[key] = {
+        samples: entry.samples.slice(-MAX_SAMPLES),
+        median: entry.median,
+        mean: entry.mean,
+        stdDev: entry.stdDev,
+        updatedAt: entry.updatedAt,
+      };
+    });
+    return { volume, iv };
+  }
+
+  return { recordVolume, recordIv, getVolumeAverage, getIvStats, toJSON };
+}
+
+export function toOccSymbol(underlying: string, row: OptRow): string {
+  const base = underlying.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+  const [year, month, day] = row.exp.split('-');
+  const yy = (year ?? '').slice(-2).padStart(2, '0');
+  const mm = (month ?? '').padStart(2, '0');
+  const dd = (day ?? '').padStart(2, '0');
+  const strike = Math.round(row.strike * 1000)
+    .toString()
+    .padStart(8, '0');
+  return `${base}${yy}${mm}${dd}${row.type}${strike}`;
+}
+
+export function getExpiryKey(row: OptRow): string {
+  return `${row.exp}|${row.type}`;
+}
+
+export function classifyMoneyness(row: OptRow, spot: number): MoneynessBucket {
+  if (!Number.isFinite(spot) || spot <= 0) {
+    return 'atm';
+  }
+  const diff = row.type === 'C' ? (row.strike - spot) / spot : (spot - row.strike) / spot;
+  if (row.type === 'C') {
+    if (diff <= -0.2) {
+      return 'deepITM';
+    }
+    if (diff <= -0.05) {
+      return 'itm';
+    }
+    if (Math.abs(diff) < 0.05) {
+      return 'atm';
+    }
+    if (diff < 0.2) {
+      return 'otm';
+    }
+    return 'deepOTM';
+  }
+  if (diff >= 0.2) {
+    return 'deepITM';
+  }
+  if (diff >= 0.05) {
+    return 'itm';
+  }
+  if (Math.abs(diff) < 0.05) {
+    return 'atm';
+  }
+  if (diff > -0.2) {
+    return 'otm';
+  }
+  return 'deepOTM';
+}
+
+export function listExpiries(rows: OptRow[]): string[] {
+  const expiries = new Set<string>();
+  rows.forEach((row) => expiries.add(row.exp));
+  return Array.from(expiries).sort();
+}
+
+function upsertSample(samples: BaselineSample[], timestamp: number, value: number) {
+  const date = toDateKey(timestamp);
+  const index = samples.findIndex((sample) => sample.date === date);
+  if (index >= 0) {
+    samples[index] = { date, value };
+  } else {
+    samples.push({ date, value });
+  }
+  samples.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+  while (samples.length > MAX_SAMPLES) {
+    samples.shift();
+  }
+}
+
+function toDateKey(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toISOString().slice(0, 10);
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return sum / values.length;
+}
+
+function computeStats(values: number[]): IvStats {
+  if (values.length === 0) {
+    return { median: 0, mean: 0, stdDev: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  const mean = average(values);
+  const variance =
+    values.length > 1
+      ? values.reduce((acc, value) => acc + (value - mean) ** 2, 0) / (values.length - 1)
+      : 0;
+  const stdDev = Math.sqrt(variance);
+  return { median, mean, stdDev };
+}

--- a/src/options/signals.ts
+++ b/src/options/signals.ts
@@ -1,0 +1,177 @@
+import type { OptRow } from '../data/optionsClient';
+import { classifyMoneyness, MONEYNESS_ORDER, type MoneynessBucket } from './chain';
+
+export interface ExpiryTotals {
+  exp: string;
+  callVolume: number;
+  putVolume: number;
+  callOpenInterest: number;
+  putOpenInterest: number;
+}
+
+export interface MoneynessCell {
+  volume: number;
+  openInterest: number;
+  rows: OptRow[];
+}
+
+export interface MoneynessRow {
+  exp: string;
+  buckets: Record<MoneynessBucket, MoneynessCell>;
+}
+
+export interface IvBaselineStats {
+  median: number;
+  mean: number;
+  stdDev: number;
+}
+
+export interface SweepSignal {
+  ts: number;
+  exp: string;
+  type: 'C' | 'P';
+  strikes: number[];
+  direction: 'up' | 'down';
+  totalVolume: number;
+}
+
+export function aggregateByExpiry(rows: OptRow[]): ExpiryTotals[] {
+  const map = new Map<string, { calls: MoneynessCell; puts: MoneynessCell }>();
+  rows.forEach((row) => {
+    const entry = map.get(row.exp) ?? {
+      calls: { volume: 0, openInterest: 0, rows: [] },
+      puts: { volume: 0, openInterest: 0, rows: [] },
+    };
+    const target = row.type === 'C' ? entry.calls : entry.puts;
+    target.volume += row.volume ?? 0;
+    target.openInterest += row.openInterest ?? 0;
+    target.rows.push(row);
+    map.set(row.exp, entry);
+  });
+  return Array.from(map.entries())
+    .map(([exp, { calls, puts }]) => ({
+      exp,
+      callVolume: calls.volume,
+      putVolume: puts.volume,
+      callOpenInterest: calls.openInterest,
+      putOpenInterest: puts.openInterest,
+    }))
+    .sort((a, b) => (a.exp < b.exp ? -1 : a.exp > b.exp ? 1 : 0));
+}
+
+export function aggregateByMoneyness(rows: OptRow[], spot: number): MoneynessRow[] {
+  const map = new Map<string, Record<MoneynessBucket, MoneynessCell>>();
+  rows.forEach((row) => {
+    const buckets = map.get(row.exp) ?? createEmptyBuckets();
+    const bucket = classifyMoneyness(row, spot);
+    const cell = buckets[bucket];
+    cell.volume += row.volume ?? 0;
+    cell.openInterest += row.openInterest ?? 0;
+    cell.rows.push(row);
+    map.set(row.exp, buckets);
+  });
+  return Array.from(map.entries())
+    .map(([exp, buckets]) => ({ exp, buckets }))
+    .sort((a, b) => (a.exp < b.exp ? -1 : a.exp > b.exp ? 1 : 0));
+}
+
+export function flagUnusualVolume(row: OptRow, baseline: number | null | undefined): boolean {
+  if (!row.volume || row.volume <= 0) {
+    return false;
+  }
+  if (baseline == null || baseline <= 0) {
+    return false;
+  }
+  return row.volume >= baseline * 3;
+}
+
+export function flagIVSpike(row: OptRow, baseline: IvBaselineStats | null | undefined): boolean {
+  if (!row.iv || row.iv <= 0) {
+    return false;
+  }
+  if (!baseline || baseline.stdDev <= 0) {
+    return false;
+  }
+  const center = baseline.median || baseline.mean || 0;
+  if (center <= 0) {
+    return false;
+  }
+  const zScore = (row.iv - center) / baseline.stdDev;
+  return zScore >= 2;
+}
+
+export function detectSweepHeuristic(rows: OptRow[]): SweepSignal[] {
+  const events: SweepSignal[] = [];
+  const seen = new Set<string>();
+  const groups = new Map<string, OptRow[]>();
+  rows.forEach((row) => {
+    if ((row.volume ?? 0) <= 0) {
+      return;
+    }
+    const key = `${row.exp}|${row.type}`;
+    const list = groups.get(key) ?? [];
+    list.push(row);
+    groups.set(key, list);
+  });
+
+  groups.forEach((group, key) => {
+    if (group.length < 3) {
+      return;
+    }
+    const sorted = [...group].sort((a, b) => (a.ts - b.ts) || (a.strike - b.strike));
+    let start = 0;
+    for (let end = 0; end < sorted.length; end += 1) {
+      while (start < end && sorted[end].ts - sorted[start].ts > 2000) {
+        start += 1;
+      }
+      const window = sorted.slice(start, end + 1);
+      if (window.length < 3) {
+        continue;
+      }
+      const strikes = window.map((row) => row.strike);
+      const isAsc = strikes.every((value, index) => index === 0 || value >= strikes[index - 1]);
+      const isDesc = strikes.every((value, index) => index === 0 || value <= strikes[index - 1]);
+      if (!isAsc && !isDesc) {
+        continue;
+      }
+      const uniqueStrikes = Array.from(new Set(strikes));
+      if (uniqueStrikes.length < 3) {
+        continue;
+      }
+      const totalVolume = window.reduce((sum, row) => sum + (row.volume ?? 0), 0);
+      if (totalVolume <= 0) {
+        continue;
+      }
+      const direction: 'up' | 'down' = isAsc ? 'up' : 'down';
+      const dedupeKey = [
+        key,
+        Math.floor(window[0].ts / 1000).toString(),
+        Math.floor(window.at(-1)!.ts / 1000).toString(),
+        direction,
+        uniqueStrikes[0]?.toString() ?? '',
+        uniqueStrikes.at(-1)?.toString() ?? '',
+      ].join('|');
+      if (seen.has(dedupeKey)) {
+        continue;
+      }
+      seen.add(dedupeKey);
+      events.push({
+        ts: window.at(-1)!.ts,
+        exp: window[0].exp,
+        type: window[0].type,
+        strikes: direction === 'up' ? [...uniqueStrikes].sort((a, b) => a - b) : [...uniqueStrikes].sort((a, b) => b - a),
+        direction,
+        totalVolume,
+      });
+    }
+  });
+
+  return events.sort((a, b) => a.ts - b.ts);
+}
+
+function createEmptyBuckets(): Record<MoneynessBucket, MoneynessCell> {
+  return MONEYNESS_ORDER.reduce((acc, bucket) => {
+    acc[bucket] = { volume: 0, openInterest: 0, rows: [] };
+    return acc;
+  }, {} as Record<MoneynessBucket, MoneynessCell>);
+}

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,0 +1,50 @@
+import type { OptRow } from './data/optionsClient';
+import type { BaselineSnapshot } from './options/chain';
+
+const STORAGE_KEY = 'gme-radar-state';
+
+export interface PersistedChainState {
+  symbol: string;
+  rows: OptRow[];
+  meta?: Record<string, unknown>;
+  spot?: number;
+  updatedAt: number;
+}
+
+export interface PersistedState {
+  symbol: string;
+  options?: {
+    chain?: PersistedChainState;
+    baselines?: BaselineSnapshot;
+  };
+}
+
+export function loadState(): PersistedState | null {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as PersistedState;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveState(state: PersistedState): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore storage failures – a fresh session still works.
+  }
+}

--- a/src/ui/alerts.ts
+++ b/src/ui/alerts.ts
@@ -1,0 +1,92 @@
+export type AlertType = 'IVSpike' | 'UnusualVol' | 'Sweep';
+
+export interface AlertEvent {
+  ts: number;
+  type: AlertType;
+  summary: string;
+  detail?: string;
+}
+
+export interface AlertsTickerHandle {
+  element: HTMLElement;
+  push(event: AlertEvent): void;
+  reset(): void;
+}
+
+const MAX_EVENTS = 40;
+const RENDER_INTERVAL = 80; // ~12.5 Hz
+
+export function createAlertsTicker(): AlertsTickerHandle {
+  const container = document.createElement('div');
+  container.className = 'alerts-ticker';
+  const title = document.createElement('strong');
+  title.textContent = 'Alerts';
+  const list = document.createElement('ul');
+  list.className = 'alerts-list';
+  container.append(title, list);
+
+  const events: AlertEvent[] = [];
+  let pending = false;
+  let lastRender = 0;
+
+  function push(event: AlertEvent) {
+    events.push(event);
+    if (events.length > MAX_EVENTS) {
+      events.splice(0, events.length - MAX_EVENTS);
+    }
+    schedule();
+  }
+
+  function reset() {
+    events.length = 0;
+    render();
+  }
+
+  function schedule() {
+    if (pending) {
+      return;
+    }
+    pending = true;
+    window.requestAnimationFrame(() => {
+      pending = false;
+      const now = Date.now();
+      if (now - lastRender < RENDER_INTERVAL) {
+        schedule();
+        return;
+      }
+      render();
+      lastRender = now;
+    });
+  }
+
+  function render() {
+    list.innerHTML = '';
+    events
+      .slice(-15)
+      .reverse()
+      .forEach((event) => {
+        const item = document.createElement('li');
+        item.className = `alert-item alert-${event.type.toLowerCase()}`;
+        const time = document.createElement('time');
+        time.textContent = formatTime(event.ts);
+        time.dateTime = new Date(event.ts).toISOString();
+        const summary = document.createElement('span');
+        summary.textContent = `${event.type}: ${event.summary}`;
+        item.append(time, summary);
+        if (event.detail) {
+          const detail = document.createElement('span');
+          detail.className = 'alert-detail';
+          detail.textContent = event.detail;
+          item.append(detail);
+        }
+        list.append(item);
+      });
+  }
+
+  return { element: container, push, reset };
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}

--- a/src/ui/optionsPanel.ts
+++ b/src/ui/optionsPanel.ts
@@ -1,0 +1,242 @@
+import type { OptRow } from '../data/optionsClient';
+import { MONEYNESS_ORDER, type MoneynessBucket } from '../options/chain';
+import type { ExpiryTotals, MoneynessRow } from '../options/signals';
+
+export interface UnusualContractRow {
+  row: OptRow;
+  contractId: string;
+  flags: string[];
+  deltaOpenInterest?: number;
+}
+
+export interface OptionsPanelHandle {
+  element: HTMLElement;
+  setSource(meta: { provider: string; delayed?: boolean; error?: string | null; updatedAt?: number | null }): void;
+  renderHeatmap(rows: MoneynessRow[]): void;
+  renderTotals(totals: ExpiryTotals[]): void;
+  renderUnusual(rows: UnusualContractRow[]): void;
+}
+
+const COLUMN_LABELS: Record<MoneynessBucket, string> = {
+  deepITM: 'Deep ITM',
+  itm: 'ITM',
+  atm: 'ATM',
+  otm: 'OTM',
+  deepOTM: 'Deep OTM',
+};
+
+export function createOptionsPanel(): OptionsPanelHandle {
+  const container = document.createElement('div');
+  container.className = 'panel options-panel';
+
+  const header = document.createElement('div');
+  header.className = 'panel-header';
+  const title = document.createElement('h2');
+  title.className = 'panel-title';
+  title.textContent = 'Options activity';
+  const providerBadge = document.createElement('span');
+  providerBadge.className = 'badge provider';
+  providerBadge.textContent = '—';
+  providerBadge.title = 'Options source';
+  header.append(title, providerBadge);
+
+  const updatedLabel = document.createElement('small');
+  updatedLabel.className = 'small';
+  updatedLabel.textContent = 'Last refresh: —';
+
+  const heatmapWrapper = document.createElement('div');
+  heatmapWrapper.className = 'heatmap-wrapper';
+  const heatmapTable = document.createElement('table');
+  heatmapTable.className = 'heatmap-table';
+  const head = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  const expiryTh = document.createElement('th');
+  expiryTh.textContent = 'Expiry';
+  headRow.append(expiryTh);
+  MONEYNESS_ORDER.forEach((bucket) => {
+    const th = document.createElement('th');
+    th.textContent = COLUMN_LABELS[bucket];
+    headRow.append(th);
+  });
+  head.append(headRow);
+  heatmapTable.append(head);
+  const body = document.createElement('tbody');
+  heatmapTable.append(body);
+  heatmapWrapper.append(heatmapTable);
+
+  const totalsStrip = document.createElement('div');
+  totalsStrip.className = 'totals-strip';
+
+  const unusualHeading = document.createElement('h3');
+  unusualHeading.textContent = 'Unusual contracts';
+  unusualHeading.className = 'section-heading';
+
+  const unusualTable = document.createElement('table');
+  unusualTable.className = 'unusual-table';
+  const unusualHead = document.createElement('thead');
+  unusualHead.innerHTML =
+    '<tr><th>Contract</th><th>Strike</th><th>Type</th><th>Vol</th><th>OI</th><th>IV</th><th>Flags</th></tr>';
+  const unusualBody = document.createElement('tbody');
+  unusualTable.append(unusualHead, unusualBody);
+
+  const legend = document.createElement('p');
+  legend.className = 'flags-legend';
+  legend.textContent = 'Flags: Vol >3× (volume spike), IV spike (>2σ move), Sweep (clustered strikes), OI Δ (open interest change).';
+
+  container.append(header, updatedLabel, heatmapWrapper, totalsStrip, unusualHeading, unusualTable, legend);
+
+  function setSource(meta: { provider: string; delayed?: boolean; error?: string | null; updatedAt?: number | null }) {
+    providerBadge.textContent = meta.provider.toUpperCase();
+    providerBadge.classList.toggle('delayed', Boolean(meta.delayed));
+    providerBadge.classList.toggle('error', Boolean(meta.error));
+    providerBadge.title = meta.error ? `Options source error: ${meta.error}` : meta.delayed ? 'Delayed data' : 'Live data';
+    if (meta.updatedAt) {
+      updatedLabel.textContent = `Last refresh: ${formatTime(meta.updatedAt)}`;
+    } else {
+      updatedLabel.textContent = 'Last refresh: —';
+    }
+  }
+
+  function renderHeatmap(rows: MoneynessRow[]) {
+    body.innerHTML = '';
+    if (rows.length === 0) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = MONEYNESS_ORDER.length + 1;
+      cell.textContent = 'No options data available';
+      cell.className = 'empty';
+      row.append(cell);
+      body.append(row);
+      return;
+    }
+    const maxVolume = rows.reduce((max, row) => {
+      return Math.max(
+        max,
+        ...MONEYNESS_ORDER.map((bucket) => row.buckets[bucket]?.volume ?? 0),
+      );
+    }, 0);
+    rows.slice(0, 8).forEach((entry) => {
+      const tr = document.createElement('tr');
+      const expiryCell = document.createElement('th');
+      expiryCell.textContent = entry.exp;
+      tr.append(expiryCell);
+      MONEYNESS_ORDER.forEach((bucket) => {
+        const cell = document.createElement('td');
+        const bucketData = entry.buckets[bucket];
+        const volume = bucketData?.volume ?? 0;
+        const oi = bucketData?.openInterest ?? 0;
+        const ratio = maxVolume > 0 ? volume / maxVolume : 0;
+        const alpha = Math.min(0.65, 0.15 + ratio * 0.6);
+        cell.style.backgroundColor = `rgba(56, 189, 248, ${alpha.toFixed(3)})`;
+        cell.className = 'heatmap-cell';
+        const best = (bucketData?.rows ?? []).slice().sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0))[0];
+        if (best) {
+          const tooltip = [
+            `${best.exp} ${best.type}${best.strike.toFixed(2)}`,
+            `Vol ${formatNumber(best.volume)} | OI ${formatNumber(best.openInterest)}`,
+          ];
+          if (best.mid != null) {
+            tooltip.push(`Mid ${best.mid.toFixed(2)}`);
+          }
+          if (best.iv != null) {
+            tooltip.push(`IV ${(best.iv * 100).toFixed(1)}%`);
+          }
+          cell.title = tooltip.join('\n');
+        } else {
+          cell.title = `${entry.exp} ${COLUMN_LABELS[bucket]}\nVol ${formatNumber(volume)} | OI ${formatNumber(oi)}`;
+        }
+        cell.innerHTML = `<strong>${formatNumber(volume)}</strong><small>OI ${formatNumber(oi)}</small>`;
+        tr.append(cell);
+      });
+      body.append(tr);
+    });
+  }
+
+  function renderTotals(totals: ExpiryTotals[]) {
+    totalsStrip.innerHTML = '';
+    if (totals.length === 0) {
+      const span = document.createElement('span');
+      span.textContent = 'Totals unavailable';
+      totalsStrip.append(span);
+      return;
+    }
+    totals
+      .slice(0, 4)
+      .forEach((total) => {
+        const item = document.createElement('div');
+        item.className = 'totals-item';
+        const heading = document.createElement('strong');
+        heading.textContent = total.exp;
+        const calls = document.createElement('span');
+        calls.textContent = `C Vol ${formatNumber(total.callVolume)} | OI ${formatNumber(total.callOpenInterest)}`;
+        const puts = document.createElement('span');
+        puts.textContent = `P Vol ${formatNumber(total.putVolume)} | OI ${formatNumber(total.putOpenInterest)}`;
+        item.append(heading, calls, puts);
+        totalsStrip.append(item);
+      });
+  }
+
+  function renderUnusual(rows: UnusualContractRow[]) {
+    unusualBody.innerHTML = '';
+    if (rows.length === 0) {
+      const empty = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.textContent = 'No unusual activity detected';
+      empty.append(cell);
+      unusualBody.append(empty);
+      return;
+    }
+    rows.slice(0, 10).forEach((entry) => {
+      const tr = document.createElement('tr');
+      const { row } = entry;
+      const contractCell = document.createElement('td');
+      contractCell.textContent = entry.contractId;
+      const strikeCell = document.createElement('td');
+      strikeCell.textContent = row.strike.toFixed(2);
+      const typeCell = document.createElement('td');
+      typeCell.textContent = row.type;
+      const volCell = document.createElement('td');
+      volCell.textContent = formatNumber(row.volume);
+      const oiCell = document.createElement('td');
+      const oiText = entry.deltaOpenInterest != null
+        ? `${formatNumber(row.openInterest)} (${formatSigned(entry.deltaOpenInterest)})`
+        : formatNumber(row.openInterest);
+      oiCell.textContent = oiText;
+      const ivCell = document.createElement('td');
+      ivCell.textContent = row.iv != null ? `${(row.iv * 100).toFixed(1)}%` : '—';
+      const flagsCell = document.createElement('td');
+      flagsCell.textContent = entry.flags.join(', ');
+      tr.append(contractCell, strikeCell, typeCell, volCell, oiCell, ivCell, flagsCell);
+      unusualBody.append(tr);
+    });
+  }
+
+  return {
+    element: container,
+    setSource,
+    renderHeatmap,
+    renderTotals,
+    renderUnusual,
+  };
+}
+
+function formatNumber(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  if (Math.abs(value) >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return value.toFixed(0);
+}
+
+function formatSigned(value: number): string {
+  const formatted = value.toFixed(0);
+  return value >= 0 ? `+${formatted}` : formatted;
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}

--- a/src/ui/status.ts
+++ b/src/ui/status.ts
@@ -12,6 +12,9 @@ export interface StatusHandle {
   setConnection(state: ConnectionState): void;
   setLastUpdated(timestamp: number | null): void;
   setRetries(count: number): void;
+  setWorkerOrigin(origin: string): void;
+  setOptionsStatus(label: string, delayed?: boolean): void;
+  setOptionsUpdated(timestamp: number | null): void;
   setBanner(message: string | null, tone?: BannerTone): void;
 }
 
@@ -44,7 +47,25 @@ export function createStatus(): StatusHandle {
   updatedLabel.setAttribute('aria-live', 'polite');
   updatedLabel.textContent = 'Last update: —';
 
-  statusLine.append(modeBadge, connectionBadge, retryLabel, updatedLabel, retryButton);
+  const workerLabel = document.createElement('span');
+  workerLabel.className = 'worker-label';
+  workerLabel.textContent = 'Worker: —';
+
+  const optionsLabel = document.createElement('span');
+  optionsLabel.className = 'options-label';
+  optionsLabel.textContent = 'Options: —';
+
+  let optionsBaseLabel = 'Options: —';
+
+  statusLine.append(
+    modeBadge,
+    connectionBadge,
+    retryLabel,
+    updatedLabel,
+    workerLabel,
+    optionsLabel,
+    retryButton,
+  );
   footer.append(statusLine);
 
   const banner = document.createElement('div');
@@ -87,6 +108,27 @@ export function createStatus(): StatusHandle {
     retryLabel.textContent = `Retries: ${count}`;
   }
 
+  function setWorkerOrigin(origin: string) {
+    workerLabel.textContent = `Worker: ${origin}`;
+  }
+
+  function setOptionsStatus(label: string, delayed = false) {
+    optionsBaseLabel = delayed ? `Options: ${label} (delayed)` : `Options: ${label}`;
+    const timestamp = optionsLabel.dataset.updatedAt;
+    optionsLabel.textContent = timestamp ? `${optionsBaseLabel} – ${formatTime(Date.parse(timestamp))}` : optionsBaseLabel;
+    optionsLabel.style.color = delayed ? '#facc15' : '#cbd5f5';
+  }
+
+  function setOptionsUpdated(timestamp: number | null) {
+    if (timestamp == null) {
+      optionsLabel.dataset.updatedAt = '';
+      optionsLabel.textContent = optionsBaseLabel;
+      return;
+    }
+    optionsLabel.dataset.updatedAt = new Date(timestamp).toISOString();
+    optionsLabel.textContent = `${optionsBaseLabel} – ${formatTime(timestamp)}`;
+  }
+
   function setBanner(message: string | null, tone: BannerTone = 'info') {
     if (!message) {
       banner.hidden = true;
@@ -108,6 +150,9 @@ export function createStatus(): StatusHandle {
     setConnection,
     setLastUpdated,
     setRetries,
+    setWorkerOrigin,
+    setOptionsStatus,
+    setOptionsUpdated,
     setBanner,
   };
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,328 @@
+interface Env {
+  FINNHUB_KEY?: string;
+  POLYGON_KEY?: string;
+}
+
+interface OptRow {
+  ts: number;
+  exp: string;
+  type: 'C' | 'P';
+  strike: number;
+  bid?: number;
+  ask?: number;
+  last?: number;
+  mid?: number;
+  volume?: number;
+  openInterest?: number;
+  iv?: number;
+}
+
+const JSON_HEADERS = {
+  'content-type': 'application/json',
+  'access-control-allow-origin': '*',
+  'access-control-allow-headers': '*,content-type',
+  'access-control-allow-methods': 'GET,OPTIONS',
+};
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: JSON_HEADERS });
+    }
+
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    try {
+      if (path.startsWith('/finnhub/quote')) {
+        return handleFinnhub(request, env, '/quote');
+      }
+      if (path.startsWith('/finnhub/stock/candle')) {
+        return handleFinnhub(request, env, '/stock/candle');
+      }
+      if (path === '/poly/options/chain') {
+        return handlePolygonOptions(url, env);
+      }
+      if (path === '/yahoo/options') {
+        return handleYahooOptions(url);
+      }
+      if (path === '/ws') {
+        return handleWebsocket(request, env, ctx);
+      }
+      return json({ error: 'Not found' }, 404);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unhandled error';
+      return json({ error: message }, 500);
+    }
+  },
+};
+
+async function handleFinnhub(request: Request, env: Env, resource: string): Promise<Response> {
+  if (!env.FINNHUB_KEY) {
+    return json({ error: 'FINNHUB_KEY unavailable' }, 501);
+  }
+  const url = new URL(`https://finnhub.io/api/v1${resource}`);
+  const requestUrl = new URL(request.url);
+  requestUrl.searchParams.forEach((value, key) => {
+    if (key !== 'token') {
+      url.searchParams.set(key, value);
+    }
+  });
+  url.searchParams.set('token', env.FINNHUB_KEY);
+  const response = await fetch(url.toString(), {
+    headers: { Accept: 'application/json' },
+  });
+  return passthroughJson(response);
+}
+
+async function handlePolygonOptions(url: URL, env: Env): Promise<Response> {
+  const symbol = url.searchParams.get('underlying');
+  if (!symbol) {
+    return json({ rows: [], meta: { source: 'polygon', error: 'Missing underlying' } }, 400);
+  }
+  if (!env.POLYGON_KEY) {
+    return json({ rows: [], meta: { source: 'polygon', error: 'Polygon key unavailable' } }, 501);
+  }
+  const upstream = new URL(`https://api.polygon.io/v3/snapshot/options/${encodeURIComponent(symbol)}`);
+  upstream.searchParams.set('limit', '1000');
+  upstream.searchParams.set('include_greeks', 'false');
+  const response = await fetch(upstream.toString(), {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${env.POLYGON_KEY}`,
+    },
+  });
+  if (response.status === 429) {
+    return json({ rows: [], meta: { source: 'polygon', error: 'Rate limited', status: 429 } }, 429);
+  }
+  if (!response.ok) {
+    return json({ rows: [], meta: { source: 'polygon', error: `Polygon error ${response.status}` } }, response.status);
+  }
+  const payload = (await response.json()) as { results?: PolygonResult[] };
+  const ts = Date.now();
+  const rows = (payload.results ?? []).flatMap((result) => normalizePolygon(result, ts)).filter((row): row is OptRow => Boolean(row));
+  return json({ rows, meta: { source: 'polygon', updatedAt: ts } });
+}
+
+async function handleYahooOptions(url: URL): Promise<Response> {
+  const symbol = url.searchParams.get('symbol');
+  if (!symbol) {
+    return json({ rows: [], meta: { source: 'yahoo', error: 'Missing symbol', delayed: true } }, 400);
+  }
+  const upstream = new URL(`https://query1.finance.yahoo.com/v7/finance/options/${encodeURIComponent(symbol)}`);
+  const response = await fetch(upstream.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'GME-Radar/1.0',
+    },
+    cf: {
+      cacheTtl: 45,
+      cacheEverything: true,
+    },
+  });
+  if (!response.ok) {
+    return json({ rows: [], meta: { source: 'yahoo', error: `Yahoo error ${response.status}`, delayed: true } }, response.status);
+  }
+  const data = (await response.json()) as YahooResponse;
+  const ts = Date.now();
+  const rows = extractYahooRows(data, ts);
+  return json({ rows, meta: { source: 'yahoo', delayed: true, updatedAt: ts } });
+}
+
+function handleWebsocket(request: Request, env: Env, ctx: ExecutionContext): Response {
+  if (!env.FINNHUB_KEY) {
+    return json({ error: 'FINNHUB_KEY unavailable' }, 501);
+  }
+  const { 0: client, 1: server } = new WebSocketPair();
+  const upstreamUrl = new URL('wss://ws.finnhub.io');
+  upstreamUrl.searchParams.set('token', env.FINNHUB_KEY);
+  const upstream = new WebSocket(upstreamUrl.toString());
+
+  server.accept();
+
+  upstream.addEventListener('message', (event) => {
+    try {
+      server.send(event.data);
+    } catch {
+      // ignored
+    }
+  });
+  upstream.addEventListener('close', () => server.close());
+  upstream.addEventListener('error', () => server.close());
+
+  server.addEventListener('message', (event) => {
+    try {
+      upstream.send(event.data);
+    } catch {
+      // ignored
+    }
+  });
+  server.addEventListener('close', () => upstream.close());
+  server.addEventListener('error', () => upstream.close());
+
+  ctx.waitUntil(
+    (async () => {
+      try {
+        await new Promise((resolve) => {
+          upstream.addEventListener('close', resolve, { once: true });
+        });
+      } finally {
+        upstream.close();
+      }
+    })(),
+  );
+
+  return new Response(null, { status: 101, webSocket: client });
+}
+
+function normalizePolygon(result: PolygonResult, fallbackTs: number): OptRow | null {
+  const exp = (result.details?.expiration_date ?? '').slice(0, 10);
+  if (!exp) {
+    return null;
+  }
+  const strike = Number(result.details?.strike_price ?? result.strike_price ?? 0);
+  if (!Number.isFinite(strike)) {
+    return null;
+  }
+  const type: 'C' | 'P' = result.details?.contract_type?.toUpperCase() === 'PUT' ? 'P' : 'C';
+  const bid = result.last_quote?.bid ?? undefined;
+  const ask = result.last_quote?.ask ?? undefined;
+  const last = result.last_trade?.price ?? undefined;
+  const volume = result.day?.volume ?? result.volume ?? undefined;
+  const openInterest = result.open_interest ?? result.open_interest_change ?? undefined;
+  const iv = result.implied_volatility ?? result.greeks?.implied_volatility ?? undefined;
+  const ts = normalizeTimestamp(result.updated, fallbackTs);
+  return {
+    ts,
+    exp,
+    type,
+    strike,
+    bid,
+    ask,
+    last,
+    volume,
+    openInterest,
+    iv,
+  };
+}
+
+function extractYahooRows(response: YahooResponse, ts: number): OptRow[] {
+  const result = response.optionChain?.result?.[0];
+  if (!result) {
+    return [];
+  }
+  const rows: OptRow[] = [];
+  const options = result.options ?? [];
+  options.forEach((option) => {
+    const exp = option.expirationDate ? new Date(option.expirationDate * 1000).toISOString().slice(0, 10) : undefined;
+    if (!exp) {
+      return;
+    }
+    for (const call of option.calls ?? []) {
+      rows.push(normalizeYahooContract(call, exp, 'C', ts));
+    }
+    for (const put of option.puts ?? []) {
+      rows.push(normalizeYahooContract(put, exp, 'P', ts));
+    }
+  });
+  return rows.filter((row) => row.strike > 0);
+}
+
+function normalizeYahooContract(contract: YahooContract, exp: string, type: 'C' | 'P', ts: number): OptRow {
+  const strike = Number(contract.strike ?? 0);
+  const bid = numberOrUndefined(contract.bid);
+  const ask = numberOrUndefined(contract.ask);
+  const last = numberOrUndefined(contract.lastPrice);
+  const volume = numberOrUndefined(contract.volume);
+  const openInterest = numberOrUndefined(contract.openInterest);
+  const iv = numberOrUndefined(contract.impliedVolatility);
+  const mid = bid != null && ask != null ? (bid + ask) / 2 : undefined;
+  return {
+    ts,
+    exp,
+    type,
+    strike,
+    bid,
+    ask,
+    last,
+    mid,
+    volume,
+    openInterest,
+    iv,
+  };
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeTimestamp(value: unknown, fallback: number): number {
+  if (typeof value === 'number') {
+    return value > 1_000_000_000_000 ? value : value * 1000;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}
+
+async function passthroughJson(response: Response): Promise<Response> {
+  const payload = await response.text();
+  return new Response(payload, {
+    status: response.status,
+    headers: JSON_HEADERS,
+  });
+}
+
+interface PolygonResult {
+  updated?: number | string;
+  strike_price?: number;
+  volume?: number;
+  open_interest?: number;
+  open_interest_change?: number;
+  implied_volatility?: number;
+  day?: { volume?: number };
+  last_quote?: { bid?: number; ask?: number };
+  last_trade?: { price?: number };
+  greeks?: { implied_volatility?: number };
+  details?: {
+    expiration_date?: string;
+    contract_type?: string;
+    strike_price?: number;
+  };
+}
+
+interface YahooResponse {
+  optionChain?: {
+    result?: Array<{
+      options?: Array<{
+        expirationDate?: number;
+        calls?: YahooContract[];
+        puts?: YahooContract[];
+      }>;
+    }>;
+  };
+}
+
+interface YahooContract {
+  strike?: number;
+  bid?: number;
+  ask?: number;
+  lastPrice?: number;
+  volume?: number;
+  openInterest?: number;
+  impliedVolatility?: number;
+}


### PR DESCRIPTION
## Summary
- add runtime config helpers and persistence to keep last options snapshot across reloads
- proxy Polygon and Yahoo chains through the worker and expose a normalized options client
- render expiry/moneyness heatmaps, unusual contract alerts, and update docs with provider guidance

## Testing
- pnpm test
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ded95261dc8327a0ac109529fd7d9e