### PR TITLE
Fix worker URL resolution for proxied worker paths

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, afterEach, beforeEach, it } from 'vitest';
+
+import { __setWorkerOriginForTests, createWorkerUrl } from './config';
+
+interface MockWindow {
+  location: { origin: string };
+}
+
+type GlobalWithWindow = typeof globalThis & { window?: MockWindow };
+
+const globalWithWindow = globalThis as GlobalWithWindow;
+const originalWindow = globalWithWindow.window;
+
+describe('createWorkerUrl', () => {
+  beforeEach(() => {
+    globalWithWindow.window = {
+      location: { origin: 'http://localhost:5173' },
+    };
+    __setWorkerOriginForTests(null);
+  });
+
+  afterEach(() => {
+    __setWorkerOriginForTests(null);
+    if (originalWindow === undefined) {
+      Reflect.deleteProperty(globalWithWindow, 'window');
+    } else {
+      globalWithWindow.window = originalWindow;
+    }
+  });
+
+  it('uses the browser origin when no worker origin is set', () => {
+    const url = createWorkerUrl('/finnhub/quote');
+    expect(url.toString()).toBe('http://localhost:5173/finnhub/quote');
+  });
+
+  it('resolves absolute worker origins', () => {
+    __setWorkerOriginForTests('https://worker.example.com');
+    const url = createWorkerUrl('/finnhub/quote');
+    expect(url.toString()).toBe('https://worker.example.com/finnhub/quote');
+  });
+
+  it('preserves worker path prefixes', () => {
+    __setWorkerOriginForTests('https://proxy.example.com/worker');
+    const url = createWorkerUrl('/finnhub/quote');
+    expect(url.toString()).toBe('https://proxy.example.com/worker/finnhub/quote');
+  });
+
+  it('handles trailing slashes on the worker origin path', () => {
+    __setWorkerOriginForTests('https://proxy.example.com/worker/');
+    const url = createWorkerUrl('/ws');
+    expect(url.toString()).toBe('https://proxy.example.com/worker/ws');
+  });
+});
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,44 @@ export function getWorkerOrigin(): string {
   return cachedOrigin;
 }
 
+function getDefaultBase(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'http://localhost';
+}
+
+function normaliseBasePath(pathname: string): string {
+  if (pathname === '/') {
+    return '';
+  }
+  return pathname.replace(/\/$/, '');
+}
+
+export function createWorkerUrl(path: string): URL {
+  const fallbackBase = getDefaultBase();
+  const origin = getWorkerOrigin();
+  if (!origin) {
+    return new URL(path, fallbackBase);
+  }
+  try {
+    const base = new URL(origin, fallbackBase);
+    if (!path.startsWith('/')) {
+      return new URL(path, base);
+    }
+    const url = new URL(base.toString());
+    const basePath = normaliseBasePath(base.pathname);
+    url.pathname = `${basePath}${path}` || '/';
+    return url;
+  } catch {
+    return new URL(path, fallbackBase);
+  }
+}
+
+export function __setWorkerOriginForTests(origin: string | null): void {
+  cachedOrigin = origin;
+}
+
 export const features: FeatureFlags = {
   demoOptionsFallback: true,
 };

--- a/src/data/workerClient.ts
+++ b/src/data/workerClient.ts
@@ -1,4 +1,4 @@
-import { getWorkerOrigin } from '../config';
+import { createWorkerUrl } from '../config';
 import type { ConnectionState, Trade } from '../types';
 
 export interface Quote {
@@ -39,15 +39,13 @@ export interface LiveConnection {
 }
 
 function createWsUrl(): string {
-  const origin = getWorkerOrigin();
-  const target = origin || window.location.origin;
-  const url = new URL('/ws', target);
+  const url = createWorkerUrl('/ws');
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();
 }
 
 export async function fetchQuote(symbol: string, signal?: AbortSignal): Promise<Quote> {
-  const url = new URL('/finnhub/quote', getWorkerOrigin() || window.location.origin);
+  const url = createWorkerUrl('/finnhub/quote');
   url.searchParams.set('symbol', symbol);
   url.searchParams.set('nocache', '1');
   const response = await fetch(url.toString(), {
@@ -68,7 +66,7 @@ export async function fetchCandles(
   resolution: '1',
   signal?: AbortSignal,
 ): Promise<Candle[]> {
-  const url = new URL('/finnhub/stock/candle', getWorkerOrigin() || window.location.origin);
+  const url = createWorkerUrl('/finnhub/stock/candle');
   url.searchParams.set('symbol', symbol);
   url.searchParams.set('resolution', resolution);
   url.searchParams.set('from', Math.floor(from / 1000).toString());

--- a/src/main.ts
+++ b/src/main.ts
@@ -660,8 +660,9 @@ function formatWorkerOrigin(): string {
     return window.location.origin;
   }
   try {
-    const url = new URL(origin);
-    return url.host;
+    const base = new URL(origin, window.location.origin);
+    const path = base.pathname === '/' ? '' : base.pathname.replace(/\/$/, '');
+    return `${base.host}${path}`;
   } catch {
     return origin;
   }


### PR DESCRIPTION
## Summary
- add a helper that resolves worker URLs while preserving any configured path prefix
- update worker client consumers and status formatting to use the new helper
- cover the new URL builder with unit tests

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dee1357a3483279f2b8f3142beb405