### PR TITLE
Provide demo options fallback for preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,56 +5,440 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>GME Radar</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
     <script type="module" src="/src/main.ts" defer></script>
     <style>
       :root {
         color-scheme: dark;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         background: #0f172a;
         color: #e2e8f0;
       }
-      * { box-sizing: border-box; }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
         margin: 0;
         min-height: 100vh;
         display: flex;
-        align-items: center;
-        justify-content: center;
+        flex-direction: column;
         background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 60%), #020617;
       }
+
+      a {
+        color: inherit;
+      }
+
       #app {
-        width: min(960px, 90vw);
-        height: min(540px, 70vh);
-        background: rgba(15, 23, 42, 0.85);
-        border-radius: 1rem;
-        padding: 1.5rem;
-        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.45);
         display: flex;
         flex-direction: column;
+        min-height: 100vh;
       }
+
       header {
+        padding: 1rem clamp(1rem, 2vw, 2.5rem);
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.5rem;
+        background: rgba(15, 23, 42, 0.9);
+        backdrop-filter: blur(6px);
+        position: sticky;
+        top: 0;
+        z-index: 2;
+      }
+
+      .header-title {
+        font-size: clamp(1.25rem, 2vw, 1.75rem);
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .header-title span:last-child {
+        font-size: 0.95rem;
+        font-weight: 400;
+        color: #94a3b8;
+      }
+
+      .header-controls {
+        display: flex;
+        align-items: flex-end;
+        gap: 1rem;
+      }
+
+      .symbol-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .symbol-form label {
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #93c5fd;
+      }
+
+      .symbol-form input {
+        width: 6rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.8);
+        color: inherit;
+      }
+
+      .symbol-form input:focus-visible {
+        outline: 2px solid #38bdf8;
+        outline-offset: 2px;
+      }
+
+      .symbol-form small {
+        font-size: 0.7rem;
+        color: #64748b;
+      }
+
+      .metrics {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: baseline;
+      }
+
+      .metrics strong {
+        font-size: clamp(1.5rem, 2.5vw, 2.1rem);
+      }
+
+      .metrics small {
+        font-size: 0.85rem;
+        color: #94a3b8;
+      }
+
+      .dashboard {
+        flex: 1;
+        display: grid;
+        gap: 1rem;
+        padding: clamp(1rem, 2vw, 2.5rem);
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1.35fr);
+        grid-template-rows: minmax(0, 1fr) minmax(0, 0.9fr) auto;
+        grid-template-areas:
+          'price options'
+          'volume options'
+          'signals options';
+      }
+
+      .panel-price { grid-area: price; }
+      .panel-volume { grid-area: volume; }
+      .panel-options { grid-area: options; }
+      .panel-signals { grid-area: signals; }
+
+      @media (max-width: 960px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .dashboard {
+          grid-template-columns: minmax(0, 1fr);
+          grid-template-rows: repeat(4, auto);
+          grid-template-areas:
+            'price'
+            'volume'
+            'signals'
+            'options';
+        }
+      }
+
+      .panel {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 0.75rem;
+        padding: 1rem;
+        background: rgba(15, 23, 42, 0.75);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-height: 0;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35);
+      }
+
+      .panel h2 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .panel-options {
+        gap: 1rem;
+      }
+
+      .panel-options h3 {
+        margin: 0;
+        font-size: 0.95rem;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: #a5b4fc;
+      }
+
+      .chart-wrapper {
+        position: relative;
+        flex: 1;
+        min-height: 240px;
+        display: flex;
+      }
+
+      .chart-wrapper canvas,
+      .chart-wrapper svg {
+        width: 100% !important;
+        height: 100% !important;
+      }
+
+      .heatmap-wrapper {
+        overflow-x: auto;
+      }
+
+      .heatmap-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+      }
+
+      .heatmap-table th,
+      .heatmap-table td {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 0.5rem;
+        text-align: left;
+      }
+
+      .heatmap-table th {
+        font-weight: 600;
+        color: #cbd5f5;
+        background: rgba(30, 41, 59, 0.65);
+      }
+
+      .heatmap-cell {
+        border-radius: 0.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-width: 110px;
+      }
+
+      .heatmap-cell strong {
+        font-size: 0.85rem;
+      }
+
+      .heatmap-cell small {
+        font-size: 0.7rem;
+        color: #e2e8f0;
+      }
+
+      .heatmap-table td.empty {
+        text-align: center;
+        color: #94a3b8;
+        padding: 1rem;
+      }
+
+      .totals-strip {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .totals-item {
+        background: rgba(30, 41, 59, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 0.6rem;
+        padding: 0.6rem 0.75rem;
+        display: grid;
+        gap: 0.25rem;
+        font-size: 0.8rem;
+      }
+
+      .unusual-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+      }
+
+      .unusual-table th,
+      .unusual-table td {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 0.4rem 0.5rem;
+        text-align: left;
+      }
+
+      .unusual-table tbody tr:hover {
+        background: rgba(56, 189, 248, 0.12);
+      }
+
+      .flags-legend {
+        margin: 0;
+        font-size: 0.7rem;
+        color: #94a3b8;
+      }
+
+      .signals-list {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.5rem 1.25rem;
+        font-size: 0.85rem;
+      }
+
+      .signals-list dt {
+        color: #94a3b8;
+      }
+
+      .alerts-block {
+        margin-top: auto;
+        padding: 0.75rem;
+        border-radius: 0.75rem;
+        background: rgba(30, 41, 59, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .alerts-block strong {
+        font-size: 0.8rem;
+        letter-spacing: 0.05em;
+        color: #a5b4fc;
+        text-transform: uppercase;
+      }
+
+      .alerts-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.35rem;
+        max-height: 120px;
+        overflow-y: auto;
+      }
+
+      .alert-item {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.35rem 0.75rem;
+        align-items: baseline;
+        font-size: 0.75rem;
+      }
+
+      .alert-item time {
+        color: #64748b;
+        font-size: 0.7rem;
+      }
+
+      .alert-detail {
+        grid-column: 2 / 3;
+        color: #cbd5f5;
+      }
+
+      footer {
+        padding: 0.75rem clamp(1rem, 2vw, 2.5rem);
+        border-top: 1px solid rgba(148, 163, 184, 0.15);
+        background: rgba(15, 23, 42, 0.85);
+        font-size: 0.85rem;
         display: flex;
         justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 1rem;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
       }
-      header h1 {
-        margin: 0;
-        font-size: 1.5rem;
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
       }
-      #price-host {
-        flex: 1;
-        min-height: 0;
+
+      .badge.live { background: rgba(34, 197, 94, 0.15); color: #4ade80; }
+      .badge.reconnecting { background: rgba(250, 204, 21, 0.15); color: #facc15; }
+      .badge.offline { background: rgba(248, 113, 113, 0.1); color: #fca5a5; }
+      .badge.demo { background: rgba(147, 197, 253, 0.15); color: #93c5fd; }
+
+      .badge.provider {
+        background: rgba(56, 189, 248, 0.18);
+        color: #bae6fd;
+        font-size: 0.7rem;
+      }
+
+      .badge.provider.delayed {
+        background: rgba(250, 204, 21, 0.18);
+        color: #fde68a;
+      }
+
+      .badge.provider.error {
+        background: rgba(248, 113, 113, 0.18);
+        color: #fecaca;
+      }
+
+      .banner {
+        width: 100%;
+        padding: 0.75rem clamp(1rem, 2vw, 2.5rem);
+        background: rgba(248, 113, 113, 0.15);
+        color: #fca5a5;
+        border-bottom: 1px solid rgba(248, 113, 113, 0.25);
+        font-size: 0.9rem;
+      }
+
+      .status-line {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.6rem 1rem;
+      }
+
+      .status-line button {
+        appearance: none;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: transparent;
+        color: inherit;
+        border-radius: 999px;
+        padding: 0.35rem 0.65rem;
+        font-size: 0.75rem;
+        cursor: pointer;
+      }
+
+      .status-line button:focus-visible {
+        outline: 2px solid #38bdf8;
+        outline-offset: 2px;
+      }
+
+      .status-line button:hover {
+        border-color: rgba(148, 163, 184, 0.8);
+      }
+
+      .status-line time {
+        color: #94a3b8;
+      }
+
+      .worker-label,
+      .options-label {
+        font-size: 0.75rem;
+        color: #cbd5f5;
+      }
+
+      .small {
+        font-size: 0.75rem;
+        color: #94a3b8;
       }
     </style>
   </head>
   <body>
-    <div id="app">
-      <header>
-        <h1>GME Radar</h1>
-        <span>Live price</span>
-      </header>
-      <div id="price-host"></div>
-    </div>
+    <noscript>
+      <div class="banner">JavaScript is required for GME Radar.</div>
+    </noscript>
+    <div id="app"></div>
   </body>
 </html>

--- a/public/demo/options.json
+++ b/public/demo/options.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "source": "demo",
+    "updatedAt": 1712251200000,
+    "delayed": true
+  },
+  "rows": [
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "C", "strike": 10, "bid": 6.25, "ask": 6.55, "last": 6.4, "volume": 128, "openInterest": 540, "iv": 0.92 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "C", "strike": 12.5, "bid": 4.05, "ask": 4.25, "last": 4.12, "volume": 256, "openInterest": 742, "iv": 0.88 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "C", "strike": 15, "bid": 2.15, "ask": 2.3, "last": 2.22, "volume": 412, "openInterest": 1105, "iv": 0.85 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "C", "strike": 17.5, "bid": 1.12, "ask": 1.23, "last": 1.2, "volume": 189, "openInterest": 980, "iv": 0.82 },
+    { "ts": 1712251200000, "exp": "2024-05-17", "type": "C", "strike": 15, "bid": 3.05, "ask": 3.25, "last": 3.15, "volume": 74, "openInterest": 650, "iv": 0.79 },
+    { "ts": 1712251200000, "exp": "2024-05-17", "type": "C", "strike": 20, "bid": 1.2, "ask": 1.35, "last": 1.28, "volume": 63, "openInterest": 540, "iv": 0.76 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "P", "strike": 10, "bid": 0.4, "ask": 0.5, "last": 0.46, "volume": 102, "openInterest": 320, "iv": 0.9 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "P", "strike": 12.5, "bid": 0.85, "ask": 0.95, "last": 0.9, "volume": 178, "openInterest": 415, "iv": 0.93 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "P", "strike": 15, "bid": 1.8, "ask": 1.95, "last": 1.88, "volume": 390, "openInterest": 830, "iv": 0.97 },
+    { "ts": 1712251200000, "exp": "2024-04-19", "type": "P", "strike": 17.5, "bid": 3.1, "ask": 3.35, "last": 3.2, "volume": 265, "openInterest": 915, "iv": 1.02 },
+    { "ts": 1712251200000, "exp": "2024-05-17", "type": "P", "strike": 15, "bid": 2.2, "ask": 2.35, "last": 2.28, "volume": 118, "openInterest": 610, "iv": 0.95 },
+    { "ts": 1712251200000, "exp": "2024-05-17", "type": "P", "strike": 20, "bid": 4.35, "ask": 4.55, "last": 4.46, "volume": 142, "openInterest": 702, "iv": 1.04 }
+  ]
+}

--- a/src/data/ohlc.ts
+++ b/src/data/ohlc.ts
@@ -1,48 +1,108 @@
-// src/data/ohlc.ts
-export interface Bar { t: number; o: number; h: number; l: number; c: number; v: number }
+import type { MinuteBar, Trade } from '../types';
 
-export class Bars {
-  private t: number[] = [];
-  private o: number[] = [];
-  private h: number[] = [];
-  private l: number[] = [];
-  private c: number[] = [];
-  private v: number[] = [];
-  private cap = 390; // ~1 trading day of 1-min bars
+const MINUTE = 60_000;
 
-  setCap(n: number) { this.cap = Math.max(1, n | 0); }
+function minuteStart(timestamp: number): number {
+  return Math.floor(timestamp / MINUTE) * MINUTE;
+}
 
-  push(b: Bar) {
-    this.t.push(b.t); this.o.push(b.o); this.h.push(b.h);
-    this.l.push(b.l); this.c.push(b.c); this.v.push(b.v);
-    if (this.t.length > this.cap) {
-      this.t.shift(); this.o.shift(); this.h.shift();
-      this.l.shift(); this.c.shift(); this.v.shift();
-    }
+export class MinuteOhlcAggregator {
+  private readonly limit: number;
+
+  private bars: MinuteBar[] = [];
+
+  constructor(limit = 390) {
+    this.limit = limit;
   }
 
-  upsertFromTrade(tsMs: number, price: number, size: number) {
-    const minute = Math.floor(tsMs / 60000) * 60000;
-    const len = this.t.length;
-    if (len && this.t[len - 1] === minute) {
-      // update last
-      this.h[len - 1] = Math.max(this.h[len - 1], price);
-      this.l[len - 1] = Math.min(this.l[len - 1], price);
-      this.c[len - 1] = price;
-      this.v[len - 1] += size;
+  seed(seedBars: MinuteBar[]): void {
+    const sorted = [...seedBars]
+      .map((bar) => ({
+        ...bar,
+        t: minuteStart(bar.t),
+      }))
+      .sort((a, b) => a.t - b.t);
+    this.bars = sorted.slice(-this.limit);
+  }
+
+  ingestTrade(trade: Trade): MinuteBar {
+    const timestamp = typeof trade.timestamp === 'number' ? trade.timestamp : Date.now();
+    const bucket = minuteStart(timestamp);
+    const existing = this.bars.at(-1);
+    if (existing && existing.t === bucket) {
+      const close = trade.price;
+      existing.c = close;
+      existing.h = Math.max(existing.h, close);
+      existing.l = Math.min(existing.l, close);
+      existing.v += trade.volume;
+      return existing;
+    }
+
+    const newBar: MinuteBar = {
+      t: bucket,
+      o: trade.price,
+      h: trade.price,
+      l: trade.price,
+      c: trade.price,
+      v: trade.volume,
+    };
+    this.bars.push(newBar);
+    if (this.bars.length > this.limit) {
+      this.bars = this.bars.slice(-this.limit);
+    }
+    return newBar;
+  }
+
+  applySnapshot(snapshot: MinuteBar[]): void {
+    if (snapshot.length === 0) {
       return;
     }
-    // new bar
-    this.push({ t: minute, o: price, h: price, l: price, c: price, v: size });
+    const normalized = snapshot
+      .map((bar) => ({ ...bar, t: minuteStart(bar.t) }))
+      .sort((a, b) => a.t - b.t);
+    const latest = this.bars.at(-1);
+    if (!latest) {
+      this.bars = normalized.slice(-this.limit);
+      return;
+    }
+    const merged = [...this.bars];
+    for (const bar of normalized) {
+      const index = merged.findIndex((existing) => existing.t === bar.t);
+      if (index >= 0) {
+        merged[index] = { ...merged[index], ...bar };
+      } else {
+        merged.push(bar);
+      }
+    }
+    this.bars = merged
+      .sort((a, b) => a.t - b.t)
+      .slice(-this.limit);
   }
 
-  applyBackfill(b: Bar) {
-    // avoid duplicates when candles + trades overlap
-    const idx = this.t.indexOf(b.t);
-    if (idx === -1) this.push(b);
+  touchPrice(price: number, timestamp: number): void {
+    const bucket = minuteStart(timestamp);
+    const latest = this.bars.at(-1);
+    if (!latest || latest.t < bucket) {
+      const bar: MinuteBar = {
+        t: bucket,
+        o: price,
+        h: price,
+        l: price,
+        c: price,
+        v: 0,
+      };
+      this.bars.push(bar);
+      if (this.bars.length > this.limit) {
+        this.bars = this.bars.slice(-this.limit);
+      }
+      return;
+    }
+    latest.c = price;
+    latest.h = Math.max(latest.h, price);
+    latest.l = Math.min(latest.l, price);
   }
 
-  arrays() {
-    return { t: this.t, o: this.o, h: this.h, l: this.l, c: this.c, v: this.v };
+  getBars(): MinuteBar[] {
+    return [...this.bars];
   }
 }

--- a/src/data/optionsClient.ts
+++ b/src/data/optionsClient.ts
@@ -1,4 +1,4 @@
-import { getWorkerOrigin } from '../config';
+import { features, getWorkerOrigin } from '../config';
 
 export interface OptRow {
   ts: number;
@@ -62,6 +62,13 @@ export async function fetchChain(symbol: string): Promise<OptionsResponse> {
     return { rows: yahooResult.payload.rows, meta };
   }
 
+  if (features.demoOptionsFallback) {
+    const demo = await loadDemoOptions(symbol);
+    if (demo) {
+      return demo;
+    }
+  }
+
   const error = yahooResult.error ?? polyResult.error ?? 'Options data unavailable';
   return {
     rows: [],
@@ -106,6 +113,51 @@ async function requestChain(path: string): Promise<RequestResult> {
     }
   }
   return { ok: false, status: 0, error: lastError ?? 'Request failed' };
+}
+
+let demoOptionsPromise: Promise<OptionsResponse | null> | null = null;
+
+function asset(path: string): string {
+  const base = (import.meta.env.BASE_URL ?? '/') as string;
+  const normalized = base.endsWith('/') ? base : `${base}/`;
+  return `${normalized}${path.replace(/^\//, '')}`;
+}
+
+async function loadDemoOptions(symbol: string): Promise<OptionsResponse | null> {
+  if (symbol.toUpperCase() !== 'GME') {
+    return null;
+  }
+  if (!demoOptionsPromise) {
+    demoOptionsPromise = (async () => {
+      try {
+        const response = await fetch(asset('demo/options.json'), {
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok) {
+          return null;
+        }
+        const payload = (await response.json()) as {
+          rows?: OptRow[];
+          meta?: OptionsMeta;
+        };
+        const rows = Array.isArray(payload.rows)
+          ? payload.rows.map(normalizeRow).filter(Boolean) as OptRow[]
+          : [];
+        if (rows.length === 0) {
+          return null;
+        }
+        const meta: OptionsMeta = {
+          source: 'demo',
+          ...payload.meta,
+          delayed: payload.meta?.delayed ?? true,
+        };
+        return { rows, meta };
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return demoOptionsPromise;
 }
 
 async function parsePayload(response: Response): Promise<OptionsResponse> {

--- a/src/data/poll.ts
+++ b/src/data/poll.ts
@@ -1,19 +1,38 @@
 // src/data/poll.ts
 type TickFn = () => void;
 
-export function ensureInterval(key: string, ms: number, fn: TickFn) {
-  const g = globalThis as any;
-  if (g[key]) return g[key] as number;
-  const id = setInterval(fn, ms) as unknown as number;
-  g[key] = id;
+type IntervalHandle = ReturnType<typeof setInterval>;
 
-  // HMR cleanup
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (import.meta?.hot) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    import.meta.hot.dispose(() => clearInterval(g[key]));
+type GlobalWithIntervals = typeof globalThis & {
+  __GME_INTERVALS__?: Map<string, IntervalHandle>;
+};
+
+const globalWithIntervals = globalThis as GlobalWithIntervals;
+
+function getIntervalStore(): Map<string, IntervalHandle> {
+  if (!globalWithIntervals.__GME_INTERVALS__) {
+    globalWithIntervals.__GME_INTERVALS__ = new Map();
   }
+  return globalWithIntervals.__GME_INTERVALS__;
+}
+
+export function ensureInterval(key: string, ms: number, fn: TickFn): IntervalHandle {
+  const store = getIntervalStore();
+  const existing = store.get(key);
+  if (existing) return existing;
+
+  const id = setInterval(fn, ms);
+  store.set(key, id);
+
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      const handle = store.get(key);
+      if (handle) {
+        clearInterval(handle);
+        store.delete(key);
+      }
+    });
+  }
+
   return id;
 }

--- a/src/data/sse.ts
+++ b/src/data/sse.ts
@@ -1,25 +1,28 @@
 // src/data/sse.ts
-let singleton: EventSource | null = (globalThis as any).__GME_SSE || null;
+type GlobalWithSSE = typeof globalThis & {
+  __GME_SSE?: EventSource | null;
+};
+
+const globalWithSSE = globalThis as GlobalWithSSE;
+
+let singleton: EventSource | null = globalWithSSE.__GME_SSE ?? null;
 
 export function connectSSE(origin = ""): EventSource {
   if (singleton) return singleton;
+
   const base = origin || (typeof location !== "undefined" ? location.origin : "");
   const es = new EventSource(new URL("/sse/alerts", base).toString(), { withCredentials: false });
-  (globalThis as any).__GME_SSE = es;
+  globalWithSSE.__GME_SSE = es;
 
   // Hot-reload cleanup to avoid duplicate streams during dev
-  // (Vite HMR calls dispose on module replacement)
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (import.meta?.hot) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+  if (import.meta.hot) {
     import.meta.hot.dispose(() => {
-      try { es.close(); } catch {}
-      (globalThis as any).__GME_SSE = null;
+      es.close();
+      globalWithSSE.__GME_SSE = null;
       singleton = null;
     });
   }
+
   singleton = es;
   return es;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,52 +1,668 @@
-// src/main.ts
-import { Bars } from "./data/ohlc";
-import { connectSSE } from "./data/sse";
-// If using Chart.js:
-// import { mountPriceChart, updatePriceChart } from "./ui/charts";
-// If using uPlot, comment the two lines above and use these instead:
-import { mountUplot as mountPriceChart, updateUplot as updatePriceChart } from "./ui/charts_uplot";
+import 'uplot/dist/uPlot.min.css';
 
-const bars = new Bars();
-bars.setCap(390);
+import { MinuteOhlcAggregator } from './data/ohlc';
+import {
+  connectLive as connectWorker,
+  fetchCandles as fetchWorkerCandles,
+  fetchQuote as fetchWorkerQuote,
+} from './data/workerClient';
+import { fetchChain, type OptRow, type OptionsResponse } from './data/optionsClient';
+import { createBaselineStore, getExpiryKey, toOccSymbol } from './options/chain';
+import {
+  aggregateByExpiry,
+  aggregateByMoneyness,
+  detectSweepHeuristic,
+  flagIVSpike,
+  flagUnusualVolume,
+  type SweepSignal,
+} from './options/signals';
+import { summarizeSignals } from './signals';
+import { createPriceChart, createVolumeChart } from './ui/charts';
+import { createOptionsPanel, type UnusualContractRow } from './ui/optionsPanel';
+import { createAlertsTicker } from './ui/alerts';
+import { createStatus } from './ui/status';
+import type { Candle, LiveConnection, Quote } from './data/workerClient';
+import type { MinuteBar, Trade } from './types';
+import {
+  connectLive as connectSimulator,
+  fetchCandles as fetchSimulatorCandles,
+  fetchQuote as fetchSimulatorQuote,
+} from './sim/simulator';
+import { getWorkerOrigin } from './config';
+import { loadState, saveState } from './persist';
 
-function boot() {
-  const host = document.getElementById("price-host")!;
-  mountPriceChart(host);
+interface OptionsSnapshotState {
+  rows: OptRow[];
+  meta: OptionsResponse['meta'];
+  spot: number | null;
+}
 
-  // Backfill once (optional): replace with your backfill call
-  // backfillBars().then(arr => arr.forEach(b => bars.applyBackfill(b)));
+const params = new URLSearchParams(window.location.search);
+const persisted = loadState();
+let symbol = (params.get('symbol') ?? persisted?.symbol ?? 'GME').toUpperCase();
+const app = document.querySelector<HTMLDivElement>('#app');
+if (!app) {
+  throw new Error('Missing app root');
+}
 
-  const es = connectSSE();
+const header = document.createElement('header');
+const title = document.createElement('h1');
+const titleLine = document.createElement('span');
+const subtitleLine = document.createElement('span');
+titleLine.textContent = 'GME Radar';
+subtitleLine.textContent = `${symbol} realtime dashboard`;
+title.append(titleLine, subtitleLine);
 
-  es.addEventListener("message", (ev) => {
-    // Generic EventSource handler: parse and route by 'type'
-    try {
-      const msg = JSON.parse((ev as MessageEvent).data);
-      if (msg?.type === "bar") {
-        const b = msg.payload as { t:number;o:number;h:number;l:number;c:number;v:number };
-        bars.applyBackfill(b);
-      } else if (msg?.type === "quote") {
-        // optionally update header UI
-      } else if (msg?.type === "trade") {
-        // if you stream trades, aggregate into minute bar
-        const d = msg.data?.[0];
-        if (d && typeof d.p === "number" && typeof d.t === "number") {
-          bars.upsertFromTrade(d.t, d.p, Number(d.v || 0));
-        }
-      }
-      const arr = bars.arrays();
-      updatePriceChart(arr.t, arr.c);
-    } catch { /* ignore bad frames */ }
-  });
+title.className = 'header-title';
 
-  // HMR: close before replace
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (import.meta?.hot) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    import.meta.hot.dispose(() => { try { es.close(); } catch {} });
+const controls = document.createElement('div');
+controls.className = 'header-controls';
+
+const symbolForm = document.createElement('form');
+symbolForm.className = 'symbol-form';
+const symbolLabel = document.createElement('label');
+symbolLabel.textContent = 'Symbol';
+symbolLabel.htmlFor = 'symbol-input';
+const symbolInput = document.createElement('input');
+symbolInput.id = 'symbol-input';
+symbolInput.type = 'text';
+symbolInput.value = symbol;
+symbolInput.maxLength = 6;
+symbolInput.autocomplete = 'off';
+const symbolHint = document.createElement('small');
+symbolHint.className = 'small';
+symbolHint.textContent = 'Press Enter to load';
+symbolForm.append(symbolLabel, symbolInput, symbolHint);
+controls.append(symbolForm);
+
+const metrics = document.createElement('div');
+metrics.className = 'metrics';
+
+const priceValue = document.createElement('strong');
+priceValue.textContent = '$0.00';
+const changeValue = document.createElement('small');
+changeValue.textContent = 'Δ 0.00 (0.00%)';
+const vwapValue = document.createElement('small');
+vwapValue.textContent = 'VWAP —';
+const rangeValue = document.createElement('small');
+rangeValue.textContent = 'Hi/Lo —';
+
+metrics.append(priceValue, changeValue, vwapValue, rangeValue);
+
+header.append(title, controls, metrics);
+app.append(header);
+
+const statusUi = createStatus();
+statusUi.banner.hidden = true;
+app.append(statusUi.banner);
+
+const main = document.createElement('main');
+main.className = 'dashboard';
+
+const pricePanel = createPanel('Price action');
+pricePanel.classList.add('panel-price');
+const priceChartContainer = document.createElement('div');
+priceChartContainer.className = 'chart-wrapper';
+pricePanel.append(priceChartContainer);
+
+const volumePanel = createPanel('Volume');
+volumePanel.classList.add('panel-volume');
+const volumeChartContainer = document.createElement('div');
+volumeChartContainer.className = 'chart-wrapper';
+volumePanel.append(volumeChartContainer);
+
+const signalPanel = createPanel('Signals & flags');
+signalPanel.classList.add('panel-signals');
+const signalsList = document.createElement('dl');
+signalsList.className = 'signals-list';
+
+const vwapItem = createSignal(signalsList, 'VWAP');
+const highItem = createSignal(signalsList, 'High');
+const lowItem = createSignal(signalsList, 'Low');
+const changeItem = createSignal(signalsList, '1m change');
+const spikeItem = createSignal(signalsList, 'Spike');
+signalPanel.append(signalsList);
+
+const optionsPanel = createOptionsPanel();
+optionsPanel.element.classList.add('panel-options');
+
+const alertsTicker = createAlertsTicker();
+alertsTicker.element.classList.add('alerts-block');
+signalPanel.append(alertsTicker.element);
+
+main.append(pricePanel, volumePanel, optionsPanel.element, signalPanel);
+app.append(main);
+app.append(statusUi.element);
+
+const priceChart = createPriceChart(priceChartContainer);
+const volumeChart = createVolumeChart(volumeChartContainer);
+
+let aggregator = new MinuteOhlcAggregator(390);
+let mode: 'worker' | 'demo' = 'worker';
+let connection: LiveConnection | null = null;
+let quoteTimer: number | undefined;
+let candleTimer: number | undefined;
+let optionsTimer: number | undefined;
+let healthTimer: number | undefined;
+let retryCount = 0;
+let lastDataAt = Date.now();
+let pendingFrame = false;
+let lastSpot: number | null = persisted?.options?.chain?.spot ?? null;
+let baselineStore = createBaselineStore(persisted?.options?.baselines);
+let lastChain: OptionsSnapshotState | null = persisted?.options?.chain
+  ? {
+      rows: persisted.options.chain.rows,
+      meta: ((persisted.options.chain.meta ?? {}) as OptionsResponse['meta']) ?? { source: 'unknown' },
+      spot: persisted.options.chain.spot ?? null,
+    }
+  : null;
+const alertHistory = new Map<string, number>();
+let optionsInFlight = false;
+
+statusUi.setMode('live');
+statusUi.setConnection('connecting');
+statusUi.setBanner(null);
+statusUi.setWorkerOrigin(formatWorkerOrigin());
+statusUi.setOptionsStatus('—');
+statusUi.setOptionsUpdated(lastChain?.rows.at(0)?.ts ?? null);
+statusUi.retryButton.addEventListener('click', () => {
+  retryCount = 0;
+  statusUi.setRetries(retryCount);
+  if (mode === 'worker') {
+    void refreshQuote();
+    void refreshCandles(true);
+    void refreshOptions(true);
+  }
+});
+statusUi.setRetries(retryCount);
+
+if (lastChain) {
+  hydrateOptionsPanel(lastChain);
+}
+
+symbolForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const next = symbolInput.value.trim().toUpperCase();
+  if (!next || next === symbol) {
+    return;
+  }
+  changeSymbol(next);
+});
+
+void bootstrap();
+
+async function bootstrap() {
+  try {
+    await loadWorker();
+  } catch (error) {
+    console.warn('Worker unavailable, switching to demo', error);
+    await enterDemo('Worker unavailable');
   }
 }
 
-boot();
+async function loadWorker() {
+  mode = 'worker';
+  statusUi.setMode('live');
+  statusUi.setBanner(null);
+  statusUi.setConnection('connecting');
+  const now = Date.now();
+  const [quote, candles] = await Promise.all([
+    fetchWorkerQuote(symbol),
+    fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1'),
+  ]);
+  aggregator = new MinuteOhlcAggregator(390);
+  const bars = convertCandles(candles);
+  aggregator.seed(bars);
+  applyQuote(quote);
+  scheduleUpdate();
+  statusUi.setConnection('connected');
+  connectStream(connectWorker(symbol));
+  quoteTimer = window.setInterval(() => {
+    void refreshQuote();
+  }, 3000);
+  candleTimer = window.setInterval(() => {
+    void refreshCandles();
+  }, 20000);
+  optionsTimer = window.setInterval(() => {
+    void refreshOptions();
+  }, 45000);
+  await refreshOptions(true);
+  startHealthCheck();
+}
+
+async function enterDemo(reason: string) {
+  mode = 'demo';
+  statusUi.setMode('demo');
+  statusUi.setBanner(`Demo mode: ${reason}`, 'info');
+  statusUi.setConnection('connected');
+  stopTimers();
+  connection?.close();
+  connection = null;
+  const [quote, candles] = await Promise.all([fetchSimulatorQuote(symbol), fetchSimulatorCandles(symbol)]);
+  aggregator = new MinuteOhlcAggregator(390);
+  aggregator.seed(candles);
+  applyQuote(quote);
+  scheduleUpdate();
+  connectStream(connectSimulator(symbol));
+  if (optionsTimer == null) {
+    optionsTimer = window.setInterval(() => {
+      void refreshOptions();
+    }, 60000);
+  }
+}
+
+function connectStream(newConnection: LiveConnection) {
+  connection?.close();
+  connection = newConnection;
+  connection.onStatus((state) => {
+    if (mode === 'demo') {
+      statusUi.setConnection('connected');
+      return;
+    }
+    statusUi.setConnection(state);
+    if (state === 'reconnecting') {
+      statusUi.setBanner('Realtime feed reconnecting…', 'info');
+    } else if (state === 'connected') {
+      statusUi.setBanner(null);
+    } else if (state === 'closed') {
+      statusUi.setBanner('Realtime feed offline – waiting for retry…', 'error');
+    }
+  });
+  connection.onPing(() => {
+    lastDataAt = Date.now();
+  });
+  connection.onTrade((trade: Trade) => {
+    lastDataAt = Date.now();
+    aggregator.ingestTrade({ ...trade, timestamp: ensureMilliseconds(trade.timestamp) });
+    scheduleUpdate();
+  });
+}
+
+async function refreshQuote() {
+  try {
+    const quote = await fetchWorkerQuote(symbol);
+    applyQuote(quote);
+    lastDataAt = Date.now();
+    scheduleUpdate();
+    retryCount = 0;
+    statusUi.setRetries(retryCount);
+  } catch (error) {
+    retryCount += 1;
+    statusUi.setRetries(retryCount);
+    const status = (error as { status?: number }).status;
+    if (status && (status === 429 || status >= 500)) {
+      statusUi.setBanner('Worker error – retrying…', 'error');
+    }
+  }
+}
+
+async function refreshCandles(force = false) {
+  if (mode !== 'worker') {
+    return;
+  }
+  try {
+    const now = Date.now();
+    const candles = await fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1');
+    aggregator.applySnapshot(convertCandles(candles));
+    if (force) {
+      scheduleUpdate();
+    }
+  } catch (error) {
+    retryCount += 1;
+    statusUi.setRetries(retryCount);
+  }
+}
+
+async function refreshOptions(suppressAlerts = false) {
+  if (optionsInFlight) {
+    return;
+  }
+  optionsInFlight = true;
+  try {
+    const response = await fetchChain(symbol);
+    if (response.rows.length === 0) {
+      const provider = response.meta?.source ? response.meta.source.toUpperCase() : 'OFFLINE';
+      optionsPanel.setSource({
+        provider,
+        delayed: Boolean(response.meta?.delayed),
+        error: response.meta?.error,
+        updatedAt: lastChain?.rows.at(0)?.ts ?? null,
+      });
+      statusUi.setOptionsStatus(provider, Boolean(response.meta?.delayed));
+      optionsInFlight = false;
+      return;
+    }
+    const spot = determineSpot();
+    lastSpot = spot;
+    const snapshot: OptionsSnapshotState = {
+      rows: response.rows,
+      meta: response.meta,
+      spot,
+    };
+    renderOptionsSnapshot(snapshot, { suppressAlerts });
+    lastChain = snapshot;
+    statusUi.setOptionsStatus(response.meta.source?.toUpperCase?.() ?? '—', Boolean(response.meta.delayed));
+    const updatedAt = response.rows[0]?.ts ?? Date.now();
+    statusUi.setOptionsUpdated(updatedAt);
+    optionsPanel.setSource({
+      provider: response.meta.source?.toUpperCase?.() ?? '—',
+      delayed: Boolean(response.meta.delayed),
+      error: response.meta.error,
+      updatedAt,
+    });
+    saveState({
+      symbol,
+      options: {
+        chain: {
+          symbol,
+          rows: response.rows,
+          meta: response.meta,
+          spot,
+          updatedAt: Date.now(),
+        },
+        baselines: baselineStore.toJSON(),
+      },
+    });
+  } catch (error) {
+    console.warn('Options fetch failed', error);
+  } finally {
+    optionsInFlight = false;
+  }
+}
+
+function renderOptionsSnapshot(snapshot: OptionsSnapshotState, opts?: { suppressAlerts?: boolean }) {
+  const { rows, spot } = snapshot;
+  const suppressAlerts = Boolean(opts?.suppressAlerts);
+  const prevMap = new Map<string, OptRow>();
+  lastChain?.rows.forEach((row) => prevMap.set(toOccSymbol(symbol, row), row));
+  const sweepEvents = detectSweepHeuristic(rows);
+  const sweepIndex = new Set<string>();
+  sweepEvents.forEach((event) => {
+    const identifier = `${event.exp}|${event.type}`;
+    event.strikes.forEach((strike) => sweepIndex.add(`${identifier}|${strike}`));
+    if (!suppressAlerts) {
+      emitSweepAlert(event);
+    }
+  });
+
+  const unusual: UnusualContractRow[] = [];
+  rows.forEach((row) => {
+    const occ = toOccSymbol(symbol, row);
+    const baseline = baselineStore.getVolumeAverage(occ);
+    const ivStats = baselineStore.getIvStats(getExpiryKey(row));
+    const volFlag = flagUnusualVolume(row, baseline);
+    const ivFlag = flagIVSpike(row, ivStats);
+    const sweepFlag = sweepIndex.has(`${row.exp}|${row.type}|${row.strike}`);
+    const previous = prevMap.get(occ);
+    const deltaOi =
+      previous && previous.openInterest != null && row.openInterest != null
+        ? row.openInterest - previous.openInterest
+        : undefined;
+    const flags: string[] = [];
+    if (volFlag) {
+      flags.push('Vol >3×');
+      if (!suppressAlerts) {
+        emitAlert(`vol:${occ}`, 'UnusualVol', `${row.type} ${row.exp} ${row.strike.toFixed(2)}`, `Vol ${formatNumber(row.volume)}`);
+      }
+    }
+    if (ivFlag) {
+      flags.push('IV spike');
+      const ivLabel = row.iv != null ? `${(row.iv * 100).toFixed(1)}%` : '—';
+      if (!suppressAlerts) {
+        emitAlert(`iv:${occ}`, 'IVSpike', `${row.type} ${row.exp} ${row.strike.toFixed(2)}`, `IV ${ivLabel}`);
+      }
+    }
+    if (sweepFlag) {
+      flags.push('Sweep');
+    }
+    if (deltaOi != null && Math.abs(deltaOi) >= determineOiThreshold(previous?.openInterest)) {
+      flags.push('OI Δ');
+    }
+    baselineStore.recordVolume(occ, row.ts, row.volume ?? 0);
+    baselineStore.recordIv(getExpiryKey(row), row.ts, row.iv ?? 0);
+    if (flags.length > 0) {
+      unusual.push({ row, contractId: occ, flags, deltaOpenInterest: deltaOi });
+    }
+  });
+
+  const matrix = aggregateByMoneyness(rows, spot ?? determineSpot());
+  const totals = aggregateByExpiry(rows);
+  optionsPanel.renderHeatmap(matrix);
+  optionsPanel.renderTotals(totals);
+  optionsPanel.renderUnusual(unusual.sort((a, b) => (b.row.volume ?? 0) - (a.row.volume ?? 0)));
+}
+
+function hydrateOptionsPanel(snapshot: OptionsSnapshotState) {
+  const meta = snapshot.meta;
+  optionsPanel.setSource({
+    provider: meta.source?.toUpperCase?.() ?? '—',
+    delayed: Boolean(meta.delayed),
+    error: meta.error,
+    updatedAt: snapshot.rows[0]?.ts ?? null,
+  });
+  statusUi.setOptionsStatus(meta.source?.toUpperCase?.() ?? '—', Boolean(meta.delayed));
+  statusUi.setOptionsUpdated(snapshot.rows[0]?.ts ?? null);
+  renderOptionsSnapshot(snapshot, { suppressAlerts: true });
+}
+
+function scheduleUpdate() {
+  if (pendingFrame) {
+    return;
+  }
+  pendingFrame = true;
+  window.requestAnimationFrame(() => {
+    pendingFrame = false;
+    const bars = aggregator.getBars();
+    priceChart.update(bars);
+    volumeChart.update(bars);
+    const summary = summarizeSignals(bars);
+    const latest = bars.at(-1);
+    if (latest) {
+      lastSpot = latest.c;
+      priceValue.textContent = formatCurrency(latest.c);
+      const prev = bars.at(-2);
+      const change = prev ? latest.c - prev.c : 0;
+      const percent = prev ? (change / prev.c) * 100 : 0;
+      changeValue.textContent = `Δ ${formatSigned(change)} (${percent.toFixed(2)}%)`;
+      changeValue.style.color = change >= 0 ? '#4ade80' : '#fca5a5';
+      statusUi.setLastUpdated(latest.t);
+      vwapValue.textContent = summary.vwap ? `VWAP ${formatCurrency(summary.vwap)}` : 'VWAP —';
+    }
+    rangeValue.textContent = formatRange(summary.high, summary.low);
+    vwapItem.textContent = summary.vwap ? formatCurrency(summary.vwap) : '—';
+    highItem.textContent = summary.high ? formatCurrency(summary.high) : '—';
+    lowItem.textContent = summary.low ? formatCurrency(summary.low) : '—';
+    const prev = bars.at(-2);
+    changeItem.textContent = prev && bars.at(-1)
+      ? formatSigned(bars.at(-1)!.c - prev.c)
+      : '—';
+    if (summary.spike) {
+      spikeItem.textContent = `${summary.spike.magnitude >= 0 ? '▲' : '▼'} ${formatSigned(summary.spike.magnitude)} (σ)`;
+    } else {
+      spikeItem.textContent = 'None';
+    }
+    spikeItem.title = 'Spike detection based on 60-minute std dev';
+  });
+}
+
+function startHealthCheck() {
+  if (healthTimer != null) {
+    window.clearInterval(healthTimer);
+  }
+  healthTimer = window.setInterval(() => {
+    if (mode === 'worker' && Date.now() - lastDataAt > 10_000) {
+      void enterDemo('Live data timeout');
+    }
+  }, 5000);
+}
+
+function stopTimers() {
+  if (quoteTimer != null) {
+    window.clearInterval(quoteTimer);
+    quoteTimer = undefined;
+  }
+  if (candleTimer != null) {
+    window.clearInterval(candleTimer);
+    candleTimer = undefined;
+  }
+  if (optionsTimer != null) {
+    window.clearInterval(optionsTimer);
+    optionsTimer = undefined;
+  }
+  if (healthTimer != null) {
+    window.clearInterval(healthTimer);
+    healthTimer = undefined;
+  }
+}
+
+function convertCandles(candles: Candle[]): MinuteBar[] {
+  return candles.map((bar) => ({
+    t: ensureMilliseconds(bar.t),
+    o: bar.o,
+    h: bar.h,
+    l: bar.l,
+    c: bar.c,
+    v: bar.v,
+  }));
+}
+
+function ensureMilliseconds(value: number): number {
+  return value > 1_000_000_000_000 ? value : value * 1000;
+}
+
+function applyQuote(quote: Quote) {
+  aggregator.touchPrice(quote.c, ensureMilliseconds(quote.t));
+  lastSpot = quote.c;
+  lastDataAt = Date.now();
+}
+
+function createPanel(title: string): HTMLDivElement {
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+  const heading = document.createElement('h2');
+  heading.textContent = title;
+  panel.append(heading);
+  return panel;
+}
+
+function createSignal(list: HTMLDListElement, label: string): HTMLSpanElement {
+  const dt = document.createElement('dt');
+  dt.textContent = label;
+  const dd = document.createElement('dd');
+  const value = document.createElement('span');
+  value.textContent = '—';
+  dd.append(value);
+  list.append(dt, dd);
+  return value;
+}
+
+function formatCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatSigned(value: number): string {
+  const fixed = value.toFixed(2);
+  return value >= 0 ? `+${fixed}` : fixed;
+}
+
+function formatRange(high: number | null, low: number | null): string {
+  if (high == null || low == null) {
+    return 'Hi/Lo —';
+  }
+  return `Hi/Lo ${formatCurrency(high)} / ${formatCurrency(low)}`;
+}
+
+function formatNumber(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  if (Math.abs(value) >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return value.toFixed(0);
+}
+
+function emitAlert(key: string, type: 'IVSpike' | 'UnusualVol', summary: string, detail?: string) {
+  const ts = Date.now();
+  const last = alertHistory.get(key);
+  if (last && ts - last < 120_000) {
+    return;
+  }
+  alertHistory.set(key, ts);
+  alertsTicker.push({ ts, type, summary, detail });
+}
+
+function emitSweepAlert(event: SweepSignal) {
+  const key = `sweep:${symbol}:${event.exp}:${event.type}:${event.strikes[0]}:${event.strikes.at(-1)}`;
+  const last = alertHistory.get(key);
+  if (last && event.ts - last < 120_000) {
+    return;
+  }
+  alertHistory.set(key, event.ts);
+  const detail = `Strikes ${event.strikes.join(' → ')} | Vol ${formatNumber(event.totalVolume)}`;
+  alertsTicker.push({
+    ts: event.ts,
+    type: 'Sweep',
+    summary: `${event.type} ${event.exp} sweep (${event.direction})`,
+    detail,
+  });
+}
+
+function determineSpot(): number {
+  if (lastSpot != null) {
+    return lastSpot;
+  }
+  const bars = aggregator.getBars();
+  const latest = bars.at(-1);
+  return latest?.c ?? 0;
+}
+
+function determineOiThreshold(previous: number | undefined | null): number {
+  if (previous == null) {
+    return 1;
+  }
+  return Math.max(1, Math.abs(previous) * 0.1);
+}
+
+function changeSymbol(next: string) {
+  stopTimers();
+  connection?.close();
+  connection = null;
+  symbol = next;
+  symbolInput.value = symbol;
+  subtitleLine.textContent = `${symbol} realtime dashboard`;
+  alertsTicker.reset();
+  lastChain = null;
+  lastSpot = null;
+  baselineStore = createBaselineStore();
+  aggregator = new MinuteOhlcAggregator(390);
+  priceChart.update([]);
+  volumeChart.update([]);
+  retryCount = 0;
+  statusUi.setRetries(0);
+  statusUi.setLastUpdated(null);
+  statusUi.setOptionsStatus('—');
+  statusUi.setOptionsUpdated(null);
+  optionsPanel.renderHeatmap([]);
+  optionsPanel.renderTotals([]);
+  optionsPanel.renderUnusual([]);
+  const url = new URL(window.location.href);
+  url.searchParams.set('symbol', symbol);
+  window.history.replaceState(null, '', url.toString());
+  alertHistory.clear();
+  saveState({ symbol });
+  void bootstrap();
+}
+
+function formatWorkerOrigin(): string {
+  const origin = getWorkerOrigin();
+  if (!origin) {
+    return window.location.origin;
+  }
+  try {
+    const url = new URL(origin);
+    return url.host;
+  } catch {
+    return origin;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static demo options snapshot that matches the dashboard schema
- load the demo snapshot when live providers fail so the options panel renders offline

## Testing
- pnpm check
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68deed3b75708327ad1111c2851af835