### PR TITLE
fix(data,ui): correct worker origin on Pages + cap/dedup chart data

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <title>GME Radar</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
+    <script>
+      // Optional: set at deploy time by editing this line once
+      window.VITE_WORKER_ORIGIN = "https://YOUR-WORKER-NAME.workers.dev";
+    </script>
     <script type="module" src="/src/main.ts" defer></script>
     <style>
       :root {

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,50 +1,56 @@
-import { describe, expect, afterEach, beforeEach, it } from 'vitest';
-
-import { __setWorkerOriginForTests, createWorkerUrl } from './config';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type GlobalWithWindow = typeof globalThis & { window?: Window & typeof globalThis };
-
 const globalWithWindow = globalThis as GlobalWithWindow;
 const originalWindow = globalWithWindow.window;
+const originalLocation = globalWithWindow.location;
 
-describe('createWorkerUrl', () => {
+describe('config', () => {
   beforeEach(() => {
-    globalWithWindow.window = {
-      location: { origin: 'http://localhost:5173' } as unknown as Location,
-    } as unknown as Window & typeof globalThis;
-    __setWorkerOriginForTests(null);
+    vi.resetModules();
+    delete (globalWithWindow as any).__VITE_WORKER_ORIGIN__;
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = {} as Window & typeof globalThis;
+    }
+    (globalWithWindow.window as any).VITE_WORKER_ORIGIN = undefined;
+    Object.defineProperty(globalWithWindow, 'location', {
+      configurable: true,
+      value: { protocol: 'https:', host: 'example.com' } as Location,
+    });
   });
 
   afterEach(() => {
-    __setWorkerOriginForTests(null);
+    vi.resetModules();
+    delete (globalWithWindow as any).__VITE_WORKER_ORIGIN__;
     if (originalWindow === undefined) {
       Reflect.deleteProperty(globalWithWindow, 'window');
     } else {
       globalWithWindow.window = originalWindow;
     }
+    if (originalLocation) {
+      Object.defineProperty(globalWithWindow, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    } else {
+      Reflect.deleteProperty(globalWithWindow, 'location');
+    }
   });
 
-  it('uses the browser origin when no worker origin is set', () => {
-    const url = createWorkerUrl('/finnhub/quote');
-    expect(url.toString()).toBe('http://localhost:5173/finnhub/quote');
+  it('falls back to browser origin when no worker origin is provided', async () => {
+    const mod = await import('./config');
+    expect(mod.WORKER_ORIGIN).toBe('https://example.com');
   });
 
-  it('resolves absolute worker origins', () => {
-    __setWorkerOriginForTests('https://worker.example.com');
-    const url = createWorkerUrl('/finnhub/quote');
-    expect(url.toString()).toBe('https://worker.example.com/finnhub/quote');
+  it('prefers injected runtime worker origin', async () => {
+    (globalWithWindow as any).__VITE_WORKER_ORIGIN__ = 'https://worker.example.com ';
+    const mod = await import('./config');
+    expect(mod.WORKER_ORIGIN).toBe('https://worker.example.com');
   });
 
-  it('preserves worker path prefixes', () => {
-    __setWorkerOriginForTests('https://proxy.example.com/worker');
-    const url = createWorkerUrl('/finnhub/quote');
-    expect(url.toString()).toBe('https://proxy.example.com/worker/finnhub/quote');
-  });
-
-  it('handles trailing slashes on the worker origin path', () => {
-    __setWorkerOriginForTests('https://proxy.example.com/worker/');
-    const url = createWorkerUrl('/ws');
-    expect(url.toString()).toBe('https://proxy.example.com/worker/ws');
+  it('builds absolute worker URLs', async () => {
+    const mod = await import('./config');
+    expect(mod.wurl('/finnhub/quote')).toBe('https://example.com/finnhub/quote');
+    expect(mod.wurl('finnhub/stock/candle')).toBe('https://example.com/finnhub/stock/candle');
   });
 });
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,58 +1,26 @@
+// src/config.ts
+// Runtime worker origin. Use absolute URL to the Cloudflare Worker.
+// Example: "https://gme-radar-rhicksrad.workers.dev"
+const ENV_ORIGIN = (globalThis as any).__VITE_WORKER_ORIGIN__ || (typeof window !== "undefined" ? (window as any).VITE_WORKER_ORIGIN : "");
+
+const FALLBACK_LOCATION = typeof location !== "undefined"
+  ? location
+  : ({ protocol: "https:", host: "localhost" } as Location);
+
+// If undefined at runtime, default to same-origin root (not the /GME base path).
+// This prevents "/GME/finnhub/…" which 404s on GitHub Pages.
+export const WORKER_ORIGIN: string =
+  typeof ENV_ORIGIN === "string" && ENV_ORIGIN.trim().length
+    ? ENV_ORIGIN.trim()
+    : `${FALLBACK_LOCATION.protocol}//${FALLBACK_LOCATION.host}`;
+
+export function wurl(path: string): string {
+  // Always resolve against origin root, never relative to /GME/*
+  return new URL(path.startsWith("/") ? path : `/${path}`, WORKER_ORIGIN).toString();
+}
+
 export interface FeatureFlags {
   demoOptionsFallback: boolean;
-}
-
-let cachedOrigin: string | null = null;
-
-export function getWorkerOrigin(): string {
-  if (cachedOrigin != null) {
-    return cachedOrigin;
-  }
-  if (typeof window === 'undefined') {
-    cachedOrigin = '';
-    return cachedOrigin;
-  }
-  const raw = (import.meta.env.VITE_WORKER_ORIGIN as string | undefined)?.trim() ?? '';
-  cachedOrigin = raw.length > 0 ? raw : window.location.origin;
-  return cachedOrigin;
-}
-
-function getDefaultBase(): string {
-  if (typeof window !== 'undefined' && window.location?.origin) {
-    return window.location.origin;
-  }
-  return 'http://localhost';
-}
-
-function normaliseBasePath(pathname: string): string {
-  if (pathname === '/') {
-    return '';
-  }
-  return pathname.replace(/\/$/, '');
-}
-
-export function createWorkerUrl(path: string): URL {
-  const fallbackBase = getDefaultBase();
-  const origin = getWorkerOrigin();
-  if (!origin) {
-    return new URL(path, fallbackBase);
-  }
-  try {
-    const base = new URL(origin, fallbackBase);
-    if (!path.startsWith('/')) {
-      return new URL(path, base);
-    }
-    const url = new URL(base.toString());
-    const basePath = normaliseBasePath(base.pathname);
-    url.pathname = `${basePath}${path}` || '/';
-    return url;
-  } catch {
-    return new URL(path, fallbackBase);
-  }
-}
-
-export function __setWorkerOriginForTests(origin: string | null): void {
-  cachedOrigin = origin;
 }
 
 export const features: FeatureFlags = {

--- a/src/data/minuteAggregator.ts
+++ b/src/data/minuteAggregator.ts
@@ -1,0 +1,81 @@
+import type { MinuteBar, Trade } from '../types';
+import { Bars, type Bar } from './ohlc';
+
+const MINUTE = 60_000;
+
+function minuteStart(timestamp: number): number {
+  return Math.floor(timestamp / MINUTE) * MINUTE;
+}
+
+function normalizeBar(bar: MinuteBar): Bar {
+  return {
+    t: minuteStart(bar.t),
+    o: bar.o,
+    h: bar.h,
+    l: bar.l,
+    c: bar.c,
+    v: bar.v,
+  };
+}
+
+export class MinuteOhlcAggregator {
+  private readonly limit: number;
+  private store: Bars;
+
+  constructor(limit = 390) {
+    this.limit = limit;
+    this.store = new Bars();
+    this.store.setCap(limit);
+  }
+
+  private reset() {
+    this.store = new Bars();
+    this.store.setCap(this.limit);
+  }
+
+  seed(seedBars: MinuteBar[]): void {
+    this.reset();
+    const normalized = [...seedBars]
+      .map(normalizeBar)
+      .sort((a, b) => a.t - b.t);
+    for (const bar of normalized) {
+      this.store.applyBackfill(bar);
+    }
+  }
+
+  ingestTrade(trade: Trade): MinuteBar {
+    const timestamp = typeof trade.timestamp === 'number' ? trade.timestamp : Date.now();
+    this.store.upsertTrade(timestamp, trade.price, trade.volume);
+    return this.getBar(minuteStart(timestamp));
+  }
+
+  applySnapshot(snapshot: MinuteBar[]): void {
+    if (snapshot.length === 0) {
+      return;
+    }
+    this.reset();
+    const normalized = [...snapshot]
+      .map(normalizeBar)
+      .sort((a, b) => a.t - b.t);
+    for (const bar of normalized) {
+      this.store.applyBackfill(bar);
+    }
+  }
+
+  touchPrice(price: number, timestamp: number): void {
+    const ts = typeof timestamp === 'number' ? timestamp : Date.now();
+    this.store.upsertTrade(ts, price, 0);
+  }
+
+  getBars(): MinuteBar[] {
+    return this.store.values().map((bar) => ({ ...bar }));
+  }
+
+  private getBar(minute: number): MinuteBar {
+    const found = this.store.values().find((bar) => bar.t === minute);
+    if (found) {
+      return { ...found };
+    }
+    return { t: minute, o: 0, h: 0, l: 0, c: 0, v: 0 };
+  }
+}

--- a/src/data/ohlc.ts
+++ b/src/data/ohlc.ts
@@ -1,108 +1,54 @@
-import type { MinuteBar, Trade } from '../types';
+export interface Bar { t: number; o: number; h: number; l: number; c: number; v: number }
 
-const MINUTE = 60_000;
+export class Bars {
+  private map = new Map<number, Bar>(); // keyed by minute epoch ms
+  private order: number[] = [];
+  private cap = 390;
 
-function minuteStart(timestamp: number): number {
-  return Math.floor(timestamp / MINUTE) * MINUTE;
-}
+  setCap(n: number) { this.cap = Math.max(1, n|0); }
 
-export class MinuteOhlcAggregator {
-  private readonly limit: number;
-
-  private bars: MinuteBar[] = [];
-
-  constructor(limit = 390) {
-    this.limit = limit;
+  applyBackfill(b: Bar) {
+    if (!this.map.has(b.t)) this.insert(b);
   }
 
-  seed(seedBars: MinuteBar[]): void {
-    const sorted = [...seedBars]
-      .map((bar) => ({
-        ...bar,
-        t: minuteStart(bar.t),
-      }))
-      .sort((a, b) => a.t - b.t);
-    this.bars = sorted.slice(-this.limit);
+  upsertTrade(tsMs: number, price: number, size = 0) {
+    const minute = Math.floor(tsMs / 60000) * 60000;
+    const existing = this.map.get(minute);
+    if (existing) {
+      existing.h = Math.max(existing.h, price);
+      existing.l = Math.min(existing.l, price);
+      existing.c = price;
+      existing.v += size;
+    } else {
+      this.insert({ t: minute, o: price, h: price, l: price, c: price, v: size });
+    }
   }
 
-  ingestTrade(trade: Trade): MinuteBar {
-    const timestamp = typeof trade.timestamp === 'number' ? trade.timestamp : Date.now();
-    const bucket = minuteStart(timestamp);
-    const existing = this.bars.at(-1);
-    if (existing && existing.t === bucket) {
-      const close = trade.price;
-      existing.c = close;
-      existing.h = Math.max(existing.h, close);
-      existing.l = Math.min(existing.l, close);
-      existing.v += trade.volume;
-      return existing;
+  private insert(b: Bar) {
+    this.map.set(b.t, { ...b });
+    // keep order sorted but cheap: append then sort occasionally
+    this.order.push(b.t);
+    if (this.order.length > 1 && this.order[this.order.length - 2] > b.t) {
+      this.order.sort((a, z) => a - z);
     }
-
-    const newBar: MinuteBar = {
-      t: bucket,
-      o: trade.price,
-      h: trade.price,
-      l: trade.price,
-      c: trade.price,
-      v: trade.volume,
-    };
-    this.bars.push(newBar);
-    if (this.bars.length > this.limit) {
-      this.bars = this.bars.slice(-this.limit);
+    // enforce cap
+    while (this.order.length > this.cap) {
+      const oldest = this.order.shift()!;
+      this.map.delete(oldest);
     }
-    return newBar;
   }
 
-  applySnapshot(snapshot: MinuteBar[]): void {
-    if (snapshot.length === 0) {
-      return;
+  arrays() {
+    const t: number[] = [];
+    const c: number[] = [];
+    for (const ts of this.order) {
+      const b = this.map.get(ts)!;
+      t.push(b.t); c.push(b.c);
     }
-    const normalized = snapshot
-      .map((bar) => ({ ...bar, t: minuteStart(bar.t) }))
-      .sort((a, b) => a.t - b.t);
-    const latest = this.bars.at(-1);
-    if (!latest) {
-      this.bars = normalized.slice(-this.limit);
-      return;
-    }
-    const merged = [...this.bars];
-    for (const bar of normalized) {
-      const index = merged.findIndex((existing) => existing.t === bar.t);
-      if (index >= 0) {
-        merged[index] = { ...merged[index], ...bar };
-      } else {
-        merged.push(bar);
-      }
-    }
-    this.bars = merged
-      .sort((a, b) => a.t - b.t)
-      .slice(-this.limit);
+    return { t, c };
   }
 
-  touchPrice(price: number, timestamp: number): void {
-    const bucket = minuteStart(timestamp);
-    const latest = this.bars.at(-1);
-    if (!latest || latest.t < bucket) {
-      const bar: MinuteBar = {
-        t: bucket,
-        o: price,
-        h: price,
-        l: price,
-        c: price,
-        v: 0,
-      };
-      this.bars.push(bar);
-      if (this.bars.length > this.limit) {
-        this.bars = this.bars.slice(-this.limit);
-      }
-      return;
-    }
-    latest.c = price;
-    latest.h = Math.max(latest.h, price);
-    latest.l = Math.min(latest.l, price);
-  }
-
-  getBars(): MinuteBar[] {
-    return [...this.bars];
+  values(): Bar[] {
+    return this.order.map((ts) => ({ ...this.map.get(ts)! }));
   }
 }

--- a/src/data/optionsClient.ts
+++ b/src/data/optionsClient.ts
@@ -1,4 +1,4 @@
-import { features, getWorkerOrigin } from '../config';
+import { features, wurl } from '../config';
 
 export interface OptRow {
   ts: number;
@@ -87,12 +87,11 @@ export async function fetchDailyOI(): Promise<OptionsResponse> {
 }
 
 async function requestChain(path: string): Promise<RequestResult> {
-  const base = getWorkerOrigin() || (typeof window !== 'undefined' ? window.location.origin : '');
-  const url = new URL(path, base);
+  const url = wurl(path);
   let lastError: string | undefined;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
     try {
-      const response = await fetch(url.toString(), {
+      const response = await fetch(url, {
         headers: { Accept: 'application/json' },
       });
       if (response.ok) {

--- a/src/data/workerClient.ts
+++ b/src/data/workerClient.ts
@@ -1,4 +1,4 @@
-import { createWorkerUrl } from '../config';
+import { wurl } from '../config';
 import type { ConnectionState, Trade } from '../types';
 
 export interface Quote {
@@ -38,22 +38,26 @@ export interface LiveConnection {
   close(): void;
 }
 
+function normalizeEpoch(value: number): number {
+  return value > 1_000_000_000_000 ? Math.floor(value / 1000) : Math.floor(value);
+}
+
 function createWsUrl(): string {
-  const url = createWorkerUrl('/ws');
+  const url = new URL(wurl('/ws'));
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();
 }
 
-export async function fetchQuote(symbol: string, signal?: AbortSignal): Promise<Quote> {
-  const url = createWorkerUrl('/finnhub/quote');
-  url.searchParams.set('symbol', symbol);
-  url.searchParams.set('nocache', '1');
-  const response = await fetch(url.toString(), {
+export async function fetchQuote(symbol = 'GME', signal?: AbortSignal): Promise<Quote> {
+  const url = wurl(`/finnhub/quote?symbol=${encodeURIComponent(symbol)}&nocache=1`);
+  const response = await fetch(url, {
+    mode: 'cors',
+    credentials: 'omit',
     headers: { Accept: 'application/json' },
     signal,
   });
   if (!response.ok) {
-    const error = new Error(`Quote request failed (${response.status})`);
+    const error = new Error(`quote ${response.status}`);
     throw Object.assign(error, { status: response.status });
   }
   return (await response.json()) as Quote;
@@ -66,24 +70,24 @@ export async function fetchCandles(
   resolution: '1',
   signal?: AbortSignal,
 ): Promise<Candle[]> {
-  const url = createWorkerUrl('/finnhub/stock/candle');
-  url.searchParams.set('symbol', symbol);
-  url.searchParams.set('resolution', resolution);
-  url.searchParams.set('from', Math.floor(from / 1000).toString());
-  url.searchParams.set('to', Math.floor(to / 1000).toString());
-  const response = await fetch(url.toString(), {
+  const url = wurl(
+    `/finnhub/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=${resolution}&from=${normalizeEpoch(from)}&to=${normalizeEpoch(to)}`,
+  );
+  const response = await fetch(url, {
+    mode: 'cors',
+    credentials: 'omit',
     headers: { Accept: 'application/json' },
     signal,
   });
   if (!response.ok) {
-    const error = new Error(`Candle request failed (${response.status})`);
+    const error = new Error(`candles ${response.status}`);
     throw Object.assign(error, { status: response.status });
   }
   const payload = (await response.json()) as CandleResponse;
   if (payload.s !== 'ok') {
     return [];
   }
-  const candles: Candle[] = payload.t.map((t, index) => ({
+  return payload.t.map((t, index) => ({
     t,
     o: payload.o[index],
     h: payload.h[index],
@@ -91,7 +95,10 @@ export async function fetchCandles(
     c: payload.c[index],
     v: payload.v[index],
   }));
-  return candles;
+}
+
+export function connectSSE(): EventSource {
+  return new EventSource(wurl('/sse/alerts'));
 }
 
 class WorkerLiveConnection implements LiveConnection {
@@ -244,4 +251,3 @@ class WorkerLiveConnection implements LiveConnection {
 export function connectLive(symbol: string): LiveConnection {
   return new WorkerLiveConnection(symbol);
 }
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import 'uplot/dist/uPlot.min.css';
 
-import { MinuteOhlcAggregator } from './data/ohlc';
+import { MinuteOhlcAggregator } from './data/minuteAggregator';
 import {
   connectLive as connectWorker,
   fetchCandles as fetchWorkerCandles,
@@ -28,7 +28,7 @@ import {
   fetchCandles as fetchSimulatorCandles,
   fetchQuote as fetchSimulatorQuote,
 } from './sim/simulator';
-import { getWorkerOrigin } from './config';
+import { WORKER_ORIGIN } from './config';
 import { loadState, saveState } from './persist';
 
 interface OptionsSnapshotState {
@@ -655,7 +655,7 @@ function changeSymbol(next: string) {
 }
 
 function formatWorkerOrigin(): string {
-  const origin = getWorkerOrigin();
+  const origin = WORKER_ORIGIN;
   if (!origin) {
     return window.location.origin;
   }

--- a/src/ui/charts.ts
+++ b/src/ui/charts.ts
@@ -6,6 +6,8 @@ function toSeconds(timestamp: number): number {
   return Math.floor(timestamp / 1000);
 }
 
+const LIMIT = 390;
+
 function buildPriceData(bars: MinuteBar[]): uPlot.AlignedData {
   const x: number[] = [];
   const open: number[] = [];
@@ -164,7 +166,8 @@ export function createPriceChart(container: HTMLElement): PriceChartHandle {
   const observer = createResizeObserver(chart, container);
   return {
     update(bars: MinuteBar[]) {
-      chart.setData(buildPriceData(bars));
+      const trimmed = bars.length > LIMIT ? bars.slice(-LIMIT) : bars;
+      chart.setData(buildPriceData(trimmed));
     },
     destroy() {
       observer.disconnect();
@@ -201,7 +204,8 @@ export function createVolumeChart(container: HTMLElement): VolumeChartHandle {
   const observer = createResizeObserver(chart, container);
   return {
     update(bars: MinuteBar[]) {
-      chart.setData(buildVolumeData(bars));
+      const trimmed = bars.length > LIMIT ? bars.slice(-LIMIT) : bars;
+      chart.setData(buildVolumeData(trimmed));
     },
     destroy() {
       observer.disconnect();


### PR DESCRIPTION
## Summary
- centralize runtime worker origin resolution and expose a `wurl()` helper for absolute URLs
- update worker/options clients to use absolute worker paths and add a Bars-backed minute aggregator
- trim chart datasets to a 390-point rolling window and document optional worker overrides for Pages

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68def25ac8f083279ebbd27124685ccc