### PR TITLE
fix(charts): replace-or-append minute bars + clamp arrays

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-type GlobalWithWindow = typeof globalThis & { window?: Window & typeof globalThis };
+type MockWindow = Window & typeof globalThis & { VITE_WORKER_ORIGIN?: string };
+type GlobalWithWindow = typeof globalThis & { window?: MockWindow; __VITE_WORKER_ORIGIN__?: string };
 const globalWithWindow = globalThis as GlobalWithWindow;
 const originalWindow = globalWithWindow.window;
 const originalLocation = globalWithWindow.location;
@@ -8,11 +9,11 @@ const originalLocation = globalWithWindow.location;
 describe('config', () => {
   beforeEach(() => {
     vi.resetModules();
-    delete (globalWithWindow as any).__VITE_WORKER_ORIGIN__;
+    delete globalWithWindow.__VITE_WORKER_ORIGIN__;
     if (!globalWithWindow.window) {
-      globalWithWindow.window = {} as Window & typeof globalThis;
+      globalWithWindow.window = {} as MockWindow;
     }
-    (globalWithWindow.window as any).VITE_WORKER_ORIGIN = undefined;
+    globalWithWindow.window.VITE_WORKER_ORIGIN = undefined;
     Object.defineProperty(globalWithWindow, 'location', {
       configurable: true,
       value: { protocol: 'https:', host: 'example.com' } as Location,
@@ -21,7 +22,7 @@ describe('config', () => {
 
   afterEach(() => {
     vi.resetModules();
-    delete (globalWithWindow as any).__VITE_WORKER_ORIGIN__;
+    delete globalWithWindow.__VITE_WORKER_ORIGIN__;
     if (originalWindow === undefined) {
       Reflect.deleteProperty(globalWithWindow, 'window');
     } else {
@@ -43,7 +44,7 @@ describe('config', () => {
   });
 
   it('prefers injected runtime worker origin', async () => {
-    (globalWithWindow as any).__VITE_WORKER_ORIGIN__ = 'https://worker.example.com ';
+    globalWithWindow.__VITE_WORKER_ORIGIN__ = 'https://worker.example.com ';
     const mod = await import('./config');
     expect(mod.WORKER_ORIGIN).toBe('https://worker.example.com');
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,13 @@
 // src/config.ts
 // Runtime worker origin. Use absolute URL to the Cloudflare Worker.
 // Example: "https://gme-radar-rhicksrad.workers.dev"
-const ENV_ORIGIN = (globalThis as any).__VITE_WORKER_ORIGIN__ || (typeof window !== "undefined" ? (window as any).VITE_WORKER_ORIGIN : "");
+type GlobalWithOrigin = typeof globalThis & { __VITE_WORKER_ORIGIN__?: string };
+type WindowWithOrigin = typeof window & { VITE_WORKER_ORIGIN?: string };
+
+const globalEnv = globalThis as GlobalWithOrigin;
+const windowEnv = typeof window !== "undefined" ? (window as WindowWithOrigin) : undefined;
+
+const ENV_ORIGIN = globalEnv.__VITE_WORKER_ORIGIN__ || windowEnv?.VITE_WORKER_ORIGIN || "";
 
 const FALLBACK_LOCATION = typeof location !== "undefined"
   ? location

--- a/src/data/minuteAggregator.ts
+++ b/src/data/minuteAggregator.ts
@@ -1,15 +1,10 @@
 import type { MinuteBar, Trade } from '../types';
 import { Bars, type Bar } from './ohlc';
-
-const MINUTE = 60_000;
-
-function minuteStart(timestamp: number): number {
-  return Math.floor(timestamp / MINUTE) * MINUTE;
-}
+import { minuteKey } from '../lib/series';
 
 function normalizeBar(bar: MinuteBar): Bar {
   return {
-    t: minuteStart(bar.t),
+    t: minuteKey(bar.t),
     o: bar.o,
     h: bar.h,
     l: bar.l,
@@ -46,7 +41,7 @@ export class MinuteOhlcAggregator {
   ingestTrade(trade: Trade): MinuteBar {
     const timestamp = typeof trade.timestamp === 'number' ? trade.timestamp : Date.now();
     this.store.upsertTrade(timestamp, trade.price, trade.volume);
-    return this.getBar(minuteStart(timestamp));
+    return this.getBar(minuteKey(timestamp));
   }
 
   applySnapshot(snapshot: MinuteBar[]): void {
@@ -71,8 +66,13 @@ export class MinuteOhlcAggregator {
     return this.store.values().map((bar) => ({ ...bar }));
   }
 
+  getArrays() {
+    return this.store.arrays();
+  }
+
   private getBar(minute: number): MinuteBar {
-    const found = this.store.values().find((bar) => bar.t === minute);
+    const bars = this.store.values();
+    const found = bars.find((bar) => bar.t === minute);
     if (found) {
       return { ...found };
     }

--- a/src/data/ohlc.ts
+++ b/src/data/ohlc.ts
@@ -1,54 +1,65 @@
+import { MAX_BARS, replaceOrAppendBar, minuteKey } from '../lib/series';
+
 export interface Bar { t: number; o: number; h: number; l: number; c: number; v: number }
 
 export class Bars {
-  private map = new Map<number, Bar>(); // keyed by minute epoch ms
-  private order: number[] = [];
-  private cap = 390;
+  public t: number[] = [];
+  public o: number[] = [];
+  public h: number[] = [];
+  public l: number[] = [];
+  public c: number[] = [];
+  public v: number[] = [];
+  private cap = MAX_BARS;
 
-  setCap(n: number) { this.cap = Math.max(1, n|0); }
+  setCap(n: number) {
+    this.cap = Math.max(1, n | 0);
+  }
 
+  /** Backfill candles: replace-if-same-t else append, then clamp */
   applyBackfill(b: Bar) {
-    if (!this.map.has(b.t)) this.insert(b);
+    replaceOrAppendBar(this.t, this.o, this.h, this.l, this.c, this.v, b, this.cap);
   }
 
+  /** Live trades → roll into current minute bar */
   upsertTrade(tsMs: number, price: number, size = 0) {
-    const minute = Math.floor(tsMs / 60000) * 60000;
-    const existing = this.map.get(minute);
-    if (existing) {
-      existing.h = Math.max(existing.h, price);
-      existing.l = Math.min(existing.l, price);
-      existing.c = price;
-      existing.v += size;
-    } else {
-      this.insert({ t: minute, o: price, h: price, l: price, c: price, v: size });
+    const t = minuteKey(tsMs);
+    const n = this.t.length;
+    if (n && this.t[n - 1] === t) {
+      // mutate last
+      this.h[n - 1] = Math.max(this.h[n - 1], price);
+      this.l[n - 1] = Math.min(this.l[n - 1], price);
+      this.c[n - 1] = price;
+      this.v[n - 1] += size;
+      return;
     }
-  }
-
-  private insert(b: Bar) {
-    this.map.set(b.t, { ...b });
-    // keep order sorted but cheap: append then sort occasionally
-    this.order.push(b.t);
-    if (this.order.length > 1 && this.order[this.order.length - 2] > b.t) {
-      this.order.sort((a, z) => a - z);
-    }
-    // enforce cap
-    while (this.order.length > this.cap) {
-      const oldest = this.order.shift()!;
-      this.map.delete(oldest);
-    }
+    replaceOrAppendBar(
+      this.t,
+      this.o,
+      this.h,
+      this.l,
+      this.c,
+      this.v,
+      { t, o: price, h: price, l: price, c: price, v: size },
+      this.cap,
+    );
   }
 
   arrays() {
-    const t: number[] = [];
-    const c: number[] = [];
-    for (const ts of this.order) {
-      const b = this.map.get(ts)!;
-      t.push(b.t); c.push(b.c);
-    }
-    return { t, c };
+    return { t: this.t, o: this.o, h: this.h, l: this.l, c: this.c, v: this.v };
   }
 
   values(): Bar[] {
-    return this.order.map((ts) => ({ ...this.map.get(ts)! }));
+    const result: Bar[] = [];
+    for (let i = 0; i < this.t.length; i += 1) {
+      result.push({
+        t: this.t[i],
+        o: this.o[i],
+        h: this.h[i],
+        l: this.l[i],
+        c: this.c[i],
+        v: this.v[i],
+      });
+    }
+    return result;
   }
 }

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,0 +1,47 @@
+export const MAX_BARS = 390;
+
+/**
+ * If the last timestamp equals `t`, replace that bar.
+ * Otherwise append a new bar. Always clamp to MAX_BARS.
+ */
+export function replaceOrAppendBar(
+  tArr: number[],
+  oArr: number[],
+  hArr: number[],
+  lArr: number[],
+  cArr: number[],
+  vArr: number[],
+  bar: { t: number; o: number; h: number; l: number; c: number; v: number },
+  cap = MAX_BARS,
+) {
+  const n = tArr.length;
+  if (n > 0 && tArr[n - 1] === bar.t) {
+    // replace last bar (NBA fix pattern)
+    oArr[n - 1] = oArr[n - 1] ?? bar.o;
+    hArr[n - 1] = Math.max(hArr[n - 1], bar.h);
+    lArr[n - 1] = Math.min(lArr[n - 1], bar.l);
+    cArr[n - 1] = bar.c;
+    vArr[n - 1] = (vArr[n - 1] || 0) + (bar.v || 0);
+  } else {
+    tArr.push(bar.t);
+    oArr.push(bar.o);
+    hArr.push(bar.h);
+    lArr.push(bar.l);
+    cArr.push(bar.c);
+    vArr.push(bar.v);
+  }
+  clampAll([tArr, oArr, hArr, lArr, cArr, vArr], cap);
+}
+
+export function clampAll(series: number[][], cap = MAX_BARS) {
+  if (series[0].length <= cap) return;
+  const start = series[0].length - cap;
+  for (const arr of series) {
+    arr.splice(0, start); // NBA page used splice for in-place clamp
+  }
+}
+
+/** Minute key used everywhere to dedup */
+export function minuteKey(tsMs: number): number {
+  return Math.floor(tsMs / 60000) * 60000;
+}

--- a/src/ui/charts.ts
+++ b/src/ui/charts.ts
@@ -1,12 +1,19 @@
 import uPlot from 'uplot';
 
 import type { MinuteBar } from '../types';
+import { MAX_BARS } from '../lib/series';
 
 function toSeconds(timestamp: number): number {
   return Math.floor(timestamp / 1000);
 }
 
-const LIMIT = 390;
+function clampAligned(data: number[][]): number[][] {
+  if (data.length === 0 || data[0].length <= MAX_BARS) {
+    return data;
+  }
+  const start = data[0].length - MAX_BARS;
+  return data.map((arr) => arr.slice(start));
+}
 
 function buildPriceData(bars: MinuteBar[]): uPlot.AlignedData {
   const x: number[] = [];
@@ -21,7 +28,7 @@ function buildPriceData(bars: MinuteBar[]): uPlot.AlignedData {
     low.push(bar.l);
     close.push(bar.c);
   }
-  return [x, open, high, low, close];
+  return clampAligned([x, open, high, low, close]) as uPlot.AlignedData;
 }
 
 function buildVolumeData(bars: MinuteBar[]): uPlot.AlignedData {
@@ -31,7 +38,7 @@ function buildVolumeData(bars: MinuteBar[]): uPlot.AlignedData {
     x.push(toSeconds(bar.t));
     volume.push(bar.v);
   }
-  return [x, volume];
+  return clampAligned([x, volume]) as uPlot.AlignedData;
 }
 
 function drawCandles(u: uPlot) {
@@ -166,8 +173,7 @@ export function createPriceChart(container: HTMLElement): PriceChartHandle {
   const observer = createResizeObserver(chart, container);
   return {
     update(bars: MinuteBar[]) {
-      const trimmed = bars.length > LIMIT ? bars.slice(-LIMIT) : bars;
-      chart.setData(buildPriceData(trimmed));
+      chart.setData(buildPriceData(bars));
     },
     destroy() {
       observer.disconnect();
@@ -204,8 +210,7 @@ export function createVolumeChart(container: HTMLElement): VolumeChartHandle {
   const observer = createResizeObserver(chart, container);
   return {
     update(bars: MinuteBar[]) {
-      const trimmed = bars.length > LIMIT ? bars.slice(-LIMIT) : bars;
-      chart.setData(buildVolumeData(trimmed));
+      chart.setData(buildVolumeData(bars));
     },
     destroy() {
       observer.disconnect();


### PR DESCRIPTION
## Summary
- add shared helpers for minute bar replacement/clamping and reuse them in the OHLC store
- update the minute aggregator and chart rendering pipeline to rely on the shared helpers and clamp datasets at render time
- tighten runtime config typing and tests to satisfy linting while preserving the absolute worker origin helper

## Testing
- pnpm run check

------
https://chatgpt.com/codex/tasks/task_e_68def55e29b083279d348d8e5c95bd38