### PR TITLE
Clamp chart render data and guard bootstrap generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
       // Optional: set at deploy time by editing this line once
       window.VITE_WORKER_ORIGIN = "https://fnproxy.hicksrch.workers.dev/";
     </script>
-    <script type="module" src="/src/main.ts" defer></script>
+    <script type="module" crossorigin src="/assets/index-Cfx4Mh2i.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D1GxaB_c.css" />
     <style>
       :root {
         color-scheme: dark;

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,7 @@ let lastChain: OptionsSnapshotState | null = persisted?.options?.chain
   : null;
 const alertHistory = new Map<string, number>();
 let optionsInFlight = false;
+let bootGeneration = 0;
 
 statusUi.setMode('live');
 statusUi.setConnection('connecting');
@@ -192,15 +193,19 @@ symbolForm.addEventListener('submit', (event) => {
 void bootstrap();
 
 async function bootstrap() {
+  const generation = ++bootGeneration;
   try {
-    await loadWorker();
+    await loadWorker(generation);
   } catch (error) {
     console.warn('Worker unavailable, switching to demo', error);
-    await enterDemo('Worker unavailable');
+    if (generation !== bootGeneration) {
+      return;
+    }
+    await enterDemo('Worker unavailable', generation);
   }
 }
 
-async function loadWorker() {
+async function loadWorker(generation: number) {
   mode = 'worker';
   statusUi.setMode('live');
   statusUi.setBanner(null);
@@ -210,13 +215,22 @@ async function loadWorker() {
     fetchWorkerQuote(symbol),
     fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1'),
   ]);
+  if (generation !== bootGeneration) {
+    return;
+  }
   aggregator = new MinuteOhlcAggregator(390);
   const bars = convertCandles(candles);
   aggregator.seed(bars);
   applyQuote(quote);
   scheduleUpdate();
   statusUi.setConnection('connected');
+  if (generation !== bootGeneration) {
+    return;
+  }
   connectStream(connectWorker(symbol));
+  if (generation !== bootGeneration) {
+    return;
+  }
   quoteTimer = window.setInterval(() => {
     void refreshQuote();
   }, 3000);
@@ -226,11 +240,20 @@ async function loadWorker() {
   optionsTimer = window.setInterval(() => {
     void refreshOptions();
   }, 45000);
+  if (generation !== bootGeneration) {
+    return;
+  }
   await refreshOptions(true);
+  if (generation !== bootGeneration) {
+    return;
+  }
   startHealthCheck();
 }
 
-async function enterDemo(reason: string) {
+async function enterDemo(reason: string, generation = bootGeneration) {
+  if (generation !== bootGeneration) {
+    return;
+  }
   mode = 'demo';
   statusUi.setMode('demo');
   statusUi.setBanner(`Demo mode: ${reason}`, 'info');
@@ -239,11 +262,20 @@ async function enterDemo(reason: string) {
   connection?.close();
   connection = null;
   const [quote, candles] = await Promise.all([fetchSimulatorQuote(symbol), fetchSimulatorCandles(symbol)]);
+  if (generation !== bootGeneration) {
+    return;
+  }
   aggregator = new MinuteOhlcAggregator(390);
   aggregator.seed(candles);
   applyQuote(quote);
   scheduleUpdate();
+  if (generation !== bootGeneration) {
+    return;
+  }
   connectStream(connectSimulator(symbol));
+  if (generation !== bootGeneration) {
+    return;
+  }
   if (optionsTimer == null) {
     optionsTimer = window.setInterval(() => {
       void refreshOptions();

--- a/src/ui/charts.ts
+++ b/src/ui/charts.ts
@@ -16,12 +16,14 @@ function clampAligned(data: number[][]): number[][] {
 }
 
 function buildPriceData(bars: MinuteBar[]): uPlot.AlignedData {
+  const start = Math.max(0, bars.length - MAX_BARS);
   const x: number[] = [];
   const open: number[] = [];
   const high: number[] = [];
   const low: number[] = [];
   const close: number[] = [];
-  for (const bar of bars) {
+  for (let i = start; i < bars.length; i += 1) {
+    const bar = bars[i];
     x.push(toSeconds(bar.t));
     open.push(bar.o);
     high.push(bar.h);
@@ -32,9 +34,11 @@ function buildPriceData(bars: MinuteBar[]): uPlot.AlignedData {
 }
 
 function buildVolumeData(bars: MinuteBar[]): uPlot.AlignedData {
+  const start = Math.max(0, bars.length - MAX_BARS);
   const x: number[] = [];
   const volume: number[] = [];
-  for (const bar of bars) {
+  for (let i = start; i < bars.length; i += 1) {
+    const bar = bars[i];
     x.push(toSeconds(bar.t));
     volume.push(bar.v);
   }


### PR DESCRIPTION
## Summary
- clamp price and volume data builders to only walk the latest MAX_BARS entries
- guard worker/demo bootstrapping with a generation counter to avoid duplicate update loops
- update index.html to point at the latest bundled assets for the worker origin override

## Testing
- pnpm run check

------
https://chatgpt.com/codex/tasks/task_e_68def7d2bc5c83278542033bf66a0136