### PR TITLE
Refactor free-tier feature detection and fallbacks

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -16,6 +16,12 @@ Pages builds must not depend on secrets or live providers.
 
 Prefer stale-but-valid UI over blank screens.
 
+Free tier fallback
+
+- The public site must tolerate environments with only `/finnhub/quote` plus slower aggregates.
+- Disable the options panel and related alerts when premium chains are inaccessible.
+- Minute bars should attempt resolution `1` first, then degrade to `5` or quotes-only mode without spamming the worker.
+
 Runtime architecture
 
 Cron jobs push normalized data into KV and publish to LiveBus DO.

--- a/index.html
+++ b/index.html
@@ -371,6 +371,7 @@
       .badge.reconnecting { background: rgba(250, 204, 21, 0.15); color: #facc15; }
       .badge.offline { background: rgba(248, 113, 113, 0.1); color: #fca5a5; }
       .badge.demo { background: rgba(147, 197, 253, 0.15); color: #93c5fd; }
+      .badge.limited { background: rgba(148, 163, 184, 0.2); color: #cbd5f5; font-size: 0.7rem; }
 
       .badge.provider {
         background: rgba(56, 189, 248, 0.18);
@@ -386,6 +387,36 @@
       .badge.provider.error {
         background: rgba(248, 113, 113, 0.18);
         color: #fecaca;
+      }
+
+      .options-content {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .panel.panel-disabled {
+        opacity: 0.6;
+        filter: grayscale(0.4);
+      }
+
+      .panel-disabled-message {
+        margin: 0;
+        padding: 0.85rem 1rem;
+        border-radius: 0.75rem;
+        border: 1px dashed rgba(148, 163, 184, 0.3);
+        background: rgba(148, 163, 184, 0.08);
+        color: #94a3b8;
+        font-size: 0.85rem;
+        display: none;
+      }
+
+      .panel.panel-disabled .panel-disabled-message {
+        display: block;
+      }
+
+      .panel.panel-disabled .options-content {
+        display: none;
       }
 
       .banner {

--- a/src/data/features.spec.ts
+++ b/src/data/features.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveFeatureState, expandCandlesToMinutes } from './features';
+import type { Candle } from './workerClient';
+
+describe('deriveFeatureState', () => {
+  it('prefers 1-minute candles when available', () => {
+    const state = deriveFeatureState({
+      quote: { ok: true, status: 200 },
+      minuteCandles: { ok: true, status: 200 },
+      fiveMinuteCandles: { ok: true, status: 200 },
+      options: { ok: true, status: 200 },
+    });
+    expect(state.candles).toBe('1');
+    expect(state.options).toBe(true);
+    expect(state.limited).toBe(false);
+  });
+
+  it('falls back to 5-minute candles and marks limited', () => {
+    const state = deriveFeatureState({
+      quote: { ok: true, status: 200 },
+      minuteCandles: { ok: false, status: 403 },
+      fiveMinuteCandles: { ok: true, status: 200 },
+      options: { ok: true, status: 200 },
+    });
+    expect(state.candles).toBe('5');
+    expect(state.limited).toBe(true);
+  });
+
+  it('disables options when unavailable', () => {
+    const state = deriveFeatureState({
+      quote: { ok: true, status: 200 },
+      minuteCandles: { ok: true, status: 200 },
+      options: { ok: false, status: 403 },
+    });
+    expect(state.options).toBe(false);
+    expect(state.limited).toBe(true);
+  });
+});
+
+describe('expandCandlesToMinutes', () => {
+  it('returns 1-minute bars unchanged', () => {
+    const candles: Candle[] = [
+      { t: 1700000000, o: 10, h: 12, l: 9, c: 11, v: 100 },
+    ];
+    const bars = expandCandlesToMinutes(candles, '1');
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toEqual({ t: 1700000000 * 1000, o: 10, h: 12, l: 9, c: 11, v: 100 });
+  });
+
+  it('upsamples 5-minute bars into 1-minute slices', () => {
+    const candles: Candle[] = [
+      { t: 1700000000, o: 20, h: 22, l: 19, c: 21, v: 500 },
+    ];
+    const bars = expandCandlesToMinutes(candles, '5');
+    expect(bars).toHaveLength(5);
+    expect(bars[0].t).toBe(1700000000 * 1000);
+    expect(bars[4].t).toBe(1700000000 * 1000 + 4 * 60_000);
+    expect(bars[0].o).toBe(20);
+    expect(bars[1].o).toBe(21);
+    expect(bars.every((bar) => bar.c === 21)).toBe(true);
+    const totalVolume = bars.reduce((sum, bar) => sum + bar.v, 0);
+    expect(totalVolume).toBeCloseTo(500);
+  });
+});

--- a/src/data/features.ts
+++ b/src/data/features.ts
@@ -1,0 +1,81 @@
+import type { Candle, CandleResolution } from './workerClient';
+import type { MinuteBar } from '../types';
+
+export interface EndpointStatus {
+  ok: boolean;
+  status?: number;
+}
+
+export interface FeatureState {
+  quote: boolean;
+  candles: CandleResolution | null;
+  options: boolean;
+  limited: boolean;
+}
+
+function isLimited(quote: boolean, candles: CandleResolution | null, options: boolean): boolean {
+  return !quote || candles !== '1' || !options;
+}
+
+export function deriveFeatureState(input: {
+  quote: EndpointStatus;
+  minuteCandles: EndpointStatus;
+  fiveMinuteCandles?: EndpointStatus;
+  options?: EndpointStatus;
+}): FeatureState {
+  const quoteAvailable = input.quote.ok;
+  const candleResolution: CandleResolution | null = input.minuteCandles.ok
+    ? '1'
+    : input.fiveMinuteCandles?.ok
+    ? '5'
+    : null;
+  const optionsAvailable = input.options?.ok ?? true;
+  return {
+    quote: quoteAvailable,
+    candles: candleResolution,
+    options: optionsAvailable,
+    limited: isLimited(quoteAvailable, candleResolution, optionsAvailable),
+  };
+}
+
+export function updateLimited(state: FeatureState): FeatureState {
+  return {
+    ...state,
+    limited: isLimited(state.quote, state.candles, state.options),
+  };
+}
+
+export function ensureMilliseconds(value: number): number {
+  return value > 1_000_000_000_000 ? Math.floor(value) : Math.floor(value * 1000);
+}
+
+export function expandCandlesToMinutes(candles: Candle[], resolution: CandleResolution): MinuteBar[] {
+  if (resolution === '1') {
+    return candles.map((bar) => ({
+      t: ensureMilliseconds(bar.t),
+      o: bar.o,
+      h: bar.h,
+      l: bar.l,
+      c: bar.c,
+      v: bar.v,
+    }));
+  }
+
+  const minutesPerBar = 5;
+  const result: MinuteBar[] = [];
+  for (const candle of candles) {
+    const start = ensureMilliseconds(candle.t);
+    const volumePerMinute = candle.v / minutesPerBar;
+    for (let i = 0; i < minutesPerBar; i += 1) {
+      result.push({
+        t: start + i * 60_000,
+        o: i === 0 ? candle.o : candle.c,
+        h: candle.h,
+        l: candle.l,
+        c: candle.c,
+        v: volumePerMinute,
+      });
+    }
+  }
+  return result;
+}

--- a/src/data/optionsClient.ts
+++ b/src/data/optionsClient.ts
@@ -1,4 +1,5 @@
 import { features, wurl } from '../config';
+import type { EndpointStatus } from './features';
 
 export interface OptRow {
   ts: number;
@@ -115,6 +116,32 @@ async function requestChain(path: string): Promise<RequestResult> {
 }
 
 let demoOptionsPromise: Promise<OptionsResponse | null> | null = null;
+
+export async function probeOptionsAvailability(symbol: string): Promise<EndpointStatus> {
+  const url = wurl(`/poly/options/chain?underlying=${encodeURIComponent(symbol)}`);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (response.body) {
+      try {
+        await response.body.cancel();
+      } catch {
+        // ignore cancel failures – this is a best-effort probe.
+      }
+    }
+    if (response.status === 403 || response.status === 401 || response.status === 404) {
+      return { ok: false, status: response.status };
+    }
+    if (response.status === 429) {
+      return { ok: true, status: response.status };
+    }
+    return { ok: response.ok, status: response.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}
 
 function asset(path: string): string {
   const base = (import.meta.env.BASE_URL ?? '/') as string;

--- a/src/data/workerClient.ts
+++ b/src/data/workerClient.ts
@@ -12,6 +12,8 @@ export interface Quote {
   t: number; // epoch seconds
 }
 
+export type CandleResolution = '1' | '5';
+
 export interface Candle {
   t: number; // epoch seconds
   o: number;
@@ -67,7 +69,7 @@ export async function fetchCandles(
   symbol: string,
   from: number,
   to: number,
-  resolution: '1',
+  resolution: CandleResolution,
   signal?: AbortSignal,
 ): Promise<Candle[]> {
   const url = wurl(

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import {
   connectLive as connectWorker,
   fetchCandles as fetchWorkerCandles,
   fetchQuote as fetchWorkerQuote,
+  type CandleResolution,
 } from './data/workerClient';
-import { fetchChain, type OptRow, type OptionsResponse } from './data/optionsClient';
+import { fetchChain, probeOptionsAvailability, type OptRow, type OptionsResponse } from './data/optionsClient';
 import { createBaselineStore, getExpiryKey, toOccSymbol } from './options/chain';
 import {
   aggregateByExpiry,
@@ -21,7 +22,7 @@ import { createPriceChart, createVolumeChart } from './ui/charts';
 import { createOptionsPanel, type UnusualContractRow } from './ui/optionsPanel';
 import { createAlertsTicker } from './ui/alerts';
 import { createStatus } from './ui/status';
-import type { Candle, LiveConnection, Quote } from './data/workerClient';
+import type { LiveConnection, Quote } from './data/workerClient';
 import type { MinuteBar, Trade } from './types';
 import {
   connectLive as connectSimulator,
@@ -30,6 +31,14 @@ import {
 } from './sim/simulator';
 import { WORKER_ORIGIN } from './config';
 import { loadState, saveState } from './persist';
+import {
+  deriveFeatureState,
+  ensureMilliseconds,
+  expandCandlesToMinutes,
+  updateLimited,
+  type EndpointStatus,
+  type FeatureState,
+} from './data/features';
 
 interface OptionsSnapshotState {
   rows: OptRow[];
@@ -49,9 +58,13 @@ const header = document.createElement('header');
 const title = document.createElement('h1');
 const titleLine = document.createElement('span');
 const subtitleLine = document.createElement('span');
+const limitedBadge = document.createElement('span');
 titleLine.textContent = 'GME Radar';
 subtitleLine.textContent = `${symbol} realtime dashboard`;
-title.append(titleLine, subtitleLine);
+limitedBadge.className = 'badge limited';
+limitedBadge.textContent = 'Limited (free tier)';
+limitedBadge.hidden = true;
+title.append(titleLine, subtitleLine, limitedBadge);
 
 title.className = 'header-title';
 
@@ -138,6 +151,7 @@ const priceChart = createPriceChart(priceChartContainer);
 const volumeChart = createVolumeChart(volumeChartContainer);
 
 let aggregator = new MinuteOhlcAggregator(390);
+let featureState: FeatureState = { quote: true, candles: '1', options: true, limited: false };
 let mode: 'worker' | 'demo' = 'worker';
 let connection: LiveConnection | null = null;
 let quoteTimer: number | undefined;
@@ -159,6 +173,10 @@ let lastChain: OptionsSnapshotState | null = persisted?.options?.chain
 const alertHistory = new Map<string, number>();
 let optionsInFlight = false;
 let bootGeneration = 0;
+let optionsDisabledReason: string | null = null;
+let quoteBackoffUntil = 0;
+let candleBackoffUntil = 0;
+let optionsBackoffUntil = 0;
 
 statusUi.setMode('live');
 statusUi.setConnection('connecting');
@@ -171,8 +189,12 @@ statusUi.retryButton.addEventListener('click', () => {
   statusUi.setRetries(retryCount);
   if (mode === 'worker') {
     void refreshQuote();
-    void refreshCandles(true);
-    void refreshOptions(true);
+    if (featureState.candles) {
+      void refreshCandles(true);
+    }
+    if (featureState.options) {
+      void refreshOptions(true);
+    }
   }
 });
 statusUi.setRetries(retryCount);
@@ -210,40 +232,86 @@ async function loadWorker(generation: number) {
   statusUi.setMode('live');
   statusUi.setBanner(null);
   statusUi.setConnection('connecting');
+  quoteBackoffUntil = 0;
+  candleBackoffUntil = 0;
+  optionsBackoffUntil = 0;
   const now = Date.now();
-  const [quote, candles] = await Promise.all([
-    fetchWorkerQuote(symbol),
-    fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1'),
-  ]);
+  const from = now - 390 * 60_000;
+
+  const quotePromise = fetchWorkerQuote(symbol);
+  let seedBars: MinuteBar[] = [];
+  let minuteStatus: EndpointStatus = { ok: false, status: 0 };
+  let fiveStatus: EndpointStatus = { ok: false, status: 0 };
+
+  try {
+    const minuteCandles = await fetchWorkerCandles(symbol, from, now, '1');
+    seedBars = expandCandlesToMinutes(minuteCandles, '1');
+    minuteStatus = { ok: true, status: 200 };
+  } catch (error) {
+    minuteStatus = extractStatus(error);
+  }
+
+  if (!minuteStatus.ok) {
+    try {
+      const fiveMinuteCandles = await fetchWorkerCandles(symbol, from, now, '5');
+      seedBars = expandCandlesToMinutes(fiveMinuteCandles, '5');
+      fiveStatus = { ok: true, status: 200 };
+    } catch (error) {
+      fiveStatus = extractStatus(error);
+    }
+  }
+
+  const quote = await quotePromise;
   if (generation !== bootGeneration) {
     return;
   }
+
+  const optionsStatus = await probeOptionsAvailability(symbol);
+  const derivedState = deriveFeatureState({
+    quote: { ok: true, status: 200 },
+    minuteCandles: minuteStatus,
+    fiveMinuteCandles: fiveStatus,
+    options: optionsStatus,
+  });
+  optionsDisabledReason = optionsStatus.ok ? null : describeOptionsStatus(optionsStatus.status);
+
   aggregator = new MinuteOhlcAggregator(390);
-  const bars = convertCandles(candles);
-  aggregator.seed(bars);
+  if (seedBars.length > 0) {
+    aggregator.seed(seedBars);
+  } else {
+    aggregator.seed([]);
+  }
   applyQuote(quote);
   scheduleUpdate();
-  statusUi.setConnection('connected');
+
   if (generation !== bootGeneration) {
     return;
   }
+
+  statusUi.setConnection('connected');
   connectStream(connectWorker(symbol));
   if (generation !== bootGeneration) {
     return;
   }
+
+  if (quoteTimer != null) {
+    window.clearInterval(quoteTimer);
+  }
   quoteTimer = window.setInterval(() => {
     void refreshQuote();
   }, 3000);
-  candleTimer = window.setInterval(() => {
-    void refreshCandles();
-  }, 20000);
-  optionsTimer = window.setInterval(() => {
-    void refreshOptions();
-  }, 45000);
+
+  applyFeatureState(derivedState, { optionsReason: optionsDisabledReason });
   if (generation !== bootGeneration) {
     return;
   }
-  await refreshOptions(true);
+
+  if (featureState.options) {
+    await refreshOptions(true);
+  } else {
+    statusUi.setOptionsStatus('DISABLED');
+    statusUi.setOptionsUpdated(null);
+  }
   if (generation !== bootGeneration) {
     return;
   }
@@ -258,6 +326,7 @@ async function enterDemo(reason: string, generation = bootGeneration) {
   statusUi.setMode('demo');
   statusUi.setBanner(`Demo mode: ${reason}`, 'info');
   statusUi.setConnection('connected');
+  applyFeatureState({ quote: true, candles: '1', options: true, limited: false });
   stopTimers();
   connection?.close();
   connection = null;
@@ -311,6 +380,9 @@ function connectStream(newConnection: LiveConnection) {
 }
 
 async function refreshQuote() {
+  if (Date.now() < quoteBackoffUntil) {
+    return;
+  }
   try {
     const quote = await fetchWorkerQuote(symbol);
     applyQuote(quote);
@@ -318,40 +390,95 @@ async function refreshQuote() {
     scheduleUpdate();
     retryCount = 0;
     statusUi.setRetries(retryCount);
+    statusUi.setBanner(null);
+    quoteBackoffUntil = 0;
   } catch (error) {
     retryCount += 1;
     statusUi.setRetries(retryCount);
     const status = (error as { status?: number }).status;
-    if (status && (status === 429 || status >= 500)) {
+    if (status === 429) {
+      statusUi.setBanner('Quote rate limited – retrying…', 'error');
+      quoteBackoffUntil = Date.now() + 5000;
+    } else if (status === 403) {
+      statusUi.setBanner('Quotes unavailable (403) – retrying later…', 'error');
+      quoteBackoffUntil = Date.now() + 60000;
+    } else if (status && status >= 500) {
       statusUi.setBanner('Worker error – retrying…', 'error');
+      quoteBackoffUntil = Date.now() + 15000;
+    } else {
+      quoteBackoffUntil = Date.now() + 10000;
     }
   }
 }
 
 async function refreshCandles(force = false) {
-  if (mode !== 'worker') {
+  if (mode !== 'worker' || !featureState.candles) {
+    return;
+  }
+  if (Date.now() < candleBackoffUntil) {
     return;
   }
   try {
-    const now = Date.now();
-    const candles = await fetchWorkerCandles(symbol, now - 390 * 60_000, now, '1');
-    aggregator.applySnapshot(convertCandles(candles));
+    const bars = await fetchCandlesSnapshot(featureState.candles);
+    aggregator.applySnapshot(bars);
     if (force) {
       scheduleUpdate();
     }
+    candleBackoffUntil = 0;
   } catch (error) {
     retryCount += 1;
     statusUi.setRetries(retryCount);
+    const status = (error as { status?: number }).status;
+    if (status === 403 || status === 401 || status === 404) {
+      if (featureState.candles === '1') {
+        const fallbackState = updateLimited({ ...featureState, candles: '5' as CandleResolution });
+        applyFeatureState(fallbackState, { optionsReason: optionsDisabledReason });
+        candleBackoffUntil = Date.now() + 60000;
+        try {
+          const fallbackBars = await fetchCandlesSnapshot('5');
+          aggregator.applySnapshot(fallbackBars);
+          scheduleUpdate();
+          candleBackoffUntil = 0;
+        } catch {
+          // Keep fallback state; retry on the next interval.
+        }
+      } else {
+        const disabledState = updateLimited({ ...featureState, candles: null });
+        applyFeatureState(disabledState, { optionsReason: optionsDisabledReason });
+        candleBackoffUntil = Date.now() + 120000;
+      }
+      return;
+    }
+    if (status === 429) {
+      candleBackoffUntil = Date.now() + 60000;
+    } else if (status && status >= 500) {
+      candleBackoffUntil = Date.now() + 45000;
+    } else {
+      candleBackoffUntil = Date.now() + 20000;
+    }
   }
 }
 
 async function refreshOptions(suppressAlerts = false) {
-  if (optionsInFlight) {
+  if (!featureState.options || optionsInFlight) {
+    return;
+  }
+  if (Date.now() < optionsBackoffUntil) {
     return;
   }
   optionsInFlight = true;
   try {
     const response = await fetchChain(symbol);
+    const status = typeof response.meta?.status === 'number' ? response.meta.status : undefined;
+    if (status === 403 || status === 401 || status === 404) {
+      optionsDisabledReason = describeOptionsStatus(status);
+      const disabledState = updateLimited({ ...featureState, options: false });
+      applyFeatureState(disabledState, { optionsReason: optionsDisabledReason });
+      return;
+    }
+    if (status === 429) {
+      optionsBackoffUntil = Date.now() + 120000;
+    }
     if (response.rows.length === 0) {
       const provider = response.meta?.source ? response.meta.source.toUpperCase() : 'OFFLINE';
       optionsPanel.setSource({
@@ -364,6 +491,7 @@ async function refreshOptions(suppressAlerts = false) {
       optionsInFlight = false;
       return;
     }
+    optionsBackoffUntil = 0;
     const spot = determineSpot();
     lastSpot = spot;
     const snapshot: OptionsSnapshotState = {
@@ -397,6 +525,7 @@ async function refreshOptions(suppressAlerts = false) {
     });
   } catch (error) {
     console.warn('Options fetch failed', error);
+    optionsBackoffUntil = Date.now() + 60000;
   } finally {
     optionsInFlight = false;
   }
@@ -547,19 +676,10 @@ function stopTimers() {
   }
 }
 
-function convertCandles(candles: Candle[]): MinuteBar[] {
-  return candles.map((bar) => ({
-    t: ensureMilliseconds(bar.t),
-    o: bar.o,
-    h: bar.h,
-    l: bar.l,
-    c: bar.c,
-    v: bar.v,
-  }));
-}
-
-function ensureMilliseconds(value: number): number {
-  return value > 1_000_000_000_000 ? value : value * 1000;
+async function fetchCandlesSnapshot(resolution: CandleResolution): Promise<MinuteBar[]> {
+  const now = Date.now();
+  const candles = await fetchWorkerCandles(symbol, now - 390 * 60_000, now, resolution);
+  return expandCandlesToMinutes(candles, resolution);
 }
 
 function applyQuote(quote: Quote) {
@@ -656,10 +776,104 @@ function determineOiThreshold(previous: number | undefined | null): number {
   return Math.max(1, Math.abs(previous) * 0.1);
 }
 
+function applyFeatureState(next: FeatureState, opts?: { optionsReason?: string | null }) {
+  const prev = featureState;
+  const normalized = updateLimited(next);
+  featureState = normalized;
+
+  if (normalized.limited) {
+    limitedBadge.hidden = false;
+    limitedBadge.textContent = limitedLabel(normalized);
+  } else {
+    limitedBadge.hidden = true;
+  }
+
+  if (!normalized.options) {
+    optionsDisabledReason = opts?.optionsReason ?? optionsDisabledReason ?? 'Options disabled (premium only)';
+    optionsPanel.setDisabled(true, optionsDisabledReason);
+    statusUi.setOptionsStatus('DISABLED');
+    statusUi.setOptionsUpdated(null);
+    if (optionsTimer != null) {
+      window.clearInterval(optionsTimer);
+      optionsTimer = undefined;
+    }
+  } else {
+    optionsDisabledReason = null;
+    optionsPanel.setDisabled(false);
+    if (!prev.options) {
+      statusUi.setOptionsStatus('—');
+      statusUi.setOptionsUpdated(null);
+    }
+    if (mode === 'worker') {
+      if (optionsTimer != null) {
+        window.clearInterval(optionsTimer);
+      }
+      optionsTimer = window.setInterval(() => {
+        void refreshOptions();
+      }, 60000);
+    }
+  }
+
+  if (!normalized.candles) {
+    if (candleTimer != null) {
+      window.clearInterval(candleTimer);
+      candleTimer = undefined;
+    }
+  } else if (mode === 'worker') {
+    const interval = normalized.candles === '1' ? 30000 : 60000;
+    if (candleTimer != null) {
+      window.clearInterval(candleTimer);
+    }
+    candleTimer = window.setInterval(() => {
+      void refreshCandles();
+    }, interval);
+  }
+}
+
+function limitedLabel(state: FeatureState): string {
+  if (!state.candles) {
+    return 'Limited (quotes only)';
+  }
+  if (state.candles === '5' && !state.options) {
+    return 'Limited (5m candles, no options)';
+  }
+  if (state.candles === '5') {
+    return 'Limited (5m candles)';
+  }
+  if (!state.options) {
+    return 'Limited (options disabled)';
+  }
+  return 'Limited (free tier)';
+}
+
+function describeOptionsStatus(status: number | undefined): string {
+  if (status === 403 || status === 401) {
+    return 'Options disabled (premium only)';
+  }
+  if (status === 404) {
+    return 'Options endpoint unavailable';
+  }
+  if (status === 429) {
+    return 'Options temporarily rate limited';
+  }
+  return 'Options data unavailable';
+}
+
+function extractStatus(error: unknown): EndpointStatus {
+  const status = (error as { status?: number })?.status;
+  return { ok: false, status: typeof status === 'number' ? status : 0 };
+}
+
 function changeSymbol(next: string) {
   stopTimers();
   connection?.close();
   connection = null;
+  featureState = { quote: true, candles: '1', options: true, limited: false };
+  optionsDisabledReason = null;
+  limitedBadge.hidden = true;
+  quoteBackoffUntil = 0;
+  candleBackoffUntil = 0;
+  optionsBackoffUntil = 0;
   symbol = next;
   symbolInput.value = symbol;
   subtitleLine.textContent = `${symbol} realtime dashboard`;
@@ -675,6 +889,8 @@ function changeSymbol(next: string) {
   statusUi.setLastUpdated(null);
   statusUi.setOptionsStatus('—');
   statusUi.setOptionsUpdated(null);
+  statusUi.setBanner(null);
+  optionsPanel.setDisabled(false);
   optionsPanel.renderHeatmap([]);
   optionsPanel.renderTotals([]);
   optionsPanel.renderUnusual([]);

--- a/src/ui/optionsPanel.ts
+++ b/src/ui/optionsPanel.ts
@@ -15,6 +15,7 @@ export interface OptionsPanelHandle {
   renderHeatmap(rows: MoneynessRow[]): void;
   renderTotals(totals: ExpiryTotals[]): void;
   renderUnusual(rows: UnusualContractRow[]): void;
+  setDisabled(disabled: boolean, reason?: string | null): void;
 }
 
 const COLUMN_LABELS: Record<MoneynessBucket, string> = {
@@ -83,7 +84,16 @@ export function createOptionsPanel(): OptionsPanelHandle {
   legend.className = 'flags-legend';
   legend.textContent = 'Flags: Vol >3× (volume spike), IV spike (>2σ move), Sweep (clustered strikes), OI Δ (open interest change).';
 
-  container.append(header, updatedLabel, heatmapWrapper, totalsStrip, unusualHeading, unusualTable, legend);
+  const content = document.createElement('div');
+  content.className = 'options-content';
+  content.append(updatedLabel, heatmapWrapper, totalsStrip, unusualHeading, unusualTable, legend);
+
+  const disabledMessage = document.createElement('div');
+  disabledMessage.className = 'panel-disabled-message';
+  disabledMessage.textContent = 'Options disabled (premium only)';
+  disabledMessage.hidden = true;
+
+  container.append(header, disabledMessage, content);
 
   function setSource(meta: { provider: string; delayed?: boolean; error?: string | null; updatedAt?: number | null }) {
     providerBadge.textContent = meta.provider.toUpperCase();
@@ -212,12 +222,20 @@ export function createOptionsPanel(): OptionsPanelHandle {
     });
   }
 
+  function setDisabled(disabled: boolean, reason?: string | null) {
+    container.classList.toggle('panel-disabled', disabled);
+    disabledMessage.hidden = !disabled;
+    disabledMessage.textContent = disabled ? reason ?? 'Options disabled (premium only)' : disabledMessage.textContent;
+    content.hidden = disabled;
+  }
+
   return {
     element: container,
     setSource,
     renderHeatmap,
     renderTotals,
     renderUnusual,
+    setDisabled,
   };
 }
 


### PR DESCRIPTION
## Summary
- probe worker endpoints on startup to detect quote, candle resolution, and options availability and toggle features accordingly
- add rate-limited polling with 5-minute upsampling fallback and limited/free-tier UI indicators
- disable the options panel when premium data is unavailable, document the behaviour, and cover the feature-state helpers with tests

## Testing
- pnpm test
- pnpm run lint
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68def96c9778832786b0dcbf1814d231