### PR TITLE
fix(build): stop pinning hashed assets in index.html; use Vite entry + %BASE_URL%

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>GME Radar</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
-    <script>
-      // Optional: set at deploy time by editing this line once
-      window.VITE_WORKER_ORIGIN = "https://fnproxy.hicksrch.workers.dev/";
-    </script>
-    <script type="module" crossorigin src="/assets/index-Cfx4Mh2i.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D1GxaB_c.css" />
+    <!-- Provide worker origin before app boots (served from /public) -->
+    <script src="%BASE_URL%worker-origin.js"></script>
+    <!-- Vite entry: let Vite build and inject hashed assets -->
+    <script type="module" src="/src/main.ts"></script>
     <style>
       :root {
         color-scheme: dark;

--- a/public/worker-origin.js
+++ b/public/worker-origin.js
@@ -1,0 +1,6 @@
+// Allow ?worker=... override, else hard-code your Worker origin for Pages.
+const qs = new URL(location.href).searchParams.get('worker');
+const DEFAULT = 'https://fnproxy.hicksrch.workers.dev';
+if (!('VITE_WORKER_ORIGIN' in window)) {
+  window.VITE_WORKER_ORIGIN = qs || DEFAULT;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite';
 
-const repository = process.env.GITHUB_REPOSITORY ?? '';
-const repoName = repository.split('/')[1] ?? '';
-const isUserPage = repoName.endsWith('.github.io');
-const base = repoName && !isUserPage ? `/${repoName}/` : '/';
-
 export default defineConfig({
-  base,
+  base: '/GME/',
   build: {
     outDir: 'dist',
     sourcemap: false,


### PR DESCRIPTION
## Summary
- update index.html to load favicon and worker helper via %BASE_URL% and let Vite manage hashed bundles
- add a public worker-origin helper script and set Vite's base path for GitHub Pages builds

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68defd92e88483278916257b8f275861